### PR TITLE
feat: automatically free import locks

### DIFF
--- a/server/src/external/mongo/db.ts
+++ b/server/src/external/mongo/db.ts
@@ -174,7 +174,9 @@ const db = {
 	"bms-course-lookup": monkDB.get<BMSCourseDocument>("bms-course-lookup"),
 	"api-tokens": monkDB.get<APITokenDocument>("api-tokens"),
 	"orphan-scores": monkDB.get<OrphanScoreDocument>("orphan-scores"),
-	"import-locks": monkDB.get<{ userID: integer; locked: boolean }>("import-locks"),
+	"import-locks": monkDB.get<{ userID: integer; locked: boolean; lockedAt: integer | null }>(
+		"import-locks"
+	),
 	tables: monkDB.get<TableDocument>("tables"),
 	"invite-locks": monkDB.get<{ userID: integer; locked: boolean }>("invite-locks"),
 	"game-settings": monkDB.get<UGPTSettingsDocument>("game-settings"),

--- a/server/src/lib/migration/migrations.ts
+++ b/server/src/lib/migration/migrations.ts
@@ -1,4 +1,5 @@
 import UserFollowersMigration from "./migrations/add-following-to-users";
+import AddLockedAt from "./migrations/add-lockedat";
 import UGPTAddPreferredRanking from "./migrations/add-preferredRanking-to-ugpt";
 import UGPTRivalsMigration from "./migrations/add-rivals-to-ugpt";
 import FixUndefinedBMSData from "./migrations/fix-undefined-bms-data";
@@ -50,6 +51,7 @@ const REGISTERED_MIGRATIONS: Array<Migration> =
 				SessionsToScoreIDs,
 				V3PropsMigration,
 				V3ScoresMigration,
+				AddLockedAt,
 		  ];
 
 // only apply type-specific migrations if we're not in testing

--- a/server/src/lib/migration/migrations/add-lockedat.ts
+++ b/server/src/lib/migration/migrations/add-lockedat.ts
@@ -1,0 +1,30 @@
+import db from "external/mongo/db";
+import type { Migration } from "utils/types";
+
+const migration: Migration = {
+	id: "add-lockedat",
+	up: async () => {
+		await db["import-locks"].update(
+			{},
+			{
+				$set: {
+					lockedAt: null,
+				},
+			},
+			{ multi: true }
+		);
+	},
+	down: async () => {
+		await db["import-locks"].update(
+			{},
+			{
+				$unset: {
+					lockedAt: 1,
+				},
+			},
+			{ multi: true }
+		);
+	},
+};
+
+export default migration;


### PR DESCRIPTION
If a lock has been held for an hour, free it automatically instead of deadlocking someones account.

This should never happen, but it did happen to a couple of users while we were restoring the database. Weird, but better than the alternative.