### PR TITLE
Remove unnecessary margin on container

### DIFF
--- a/homepage/src/style.scss
+++ b/homepage/src/style.scss
@@ -57,7 +57,7 @@ body {
 	flex-direction: column;
 	min-height: 100vh;
 	max-width: 90ch;
-	margin: 0 auto var(--md-gap);
+	margin: 0 auto;
 	padding: var(--md-padding);
 
 	.content {


### PR DESCRIPTION
The margin on the bottom of the container causes excess scroll on larger displays. 

This can be safely removed.