### PR TITLE
fix: IIDX metadata fixes

### DIFF
--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -20126,7 +20126,9 @@
 		"title": "Echo Of Forever"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"Reflection Into the EDEN"
+		],
 		"artist": "猫叉Master",
 		"data": {
 			"displayVersion": "20",


### PR DESCRIPTION
This removes the another charts from Strong Jaeger in Infinitas, they are only available in CS and Omnimix (likely an oversight when the song was added to Infinitas)

This also adds an alt-title to Reflection Into the Eden to match eamuse CSVs