### PR TITLE
fix(client): make folder lists more readable

### DIFF
--- a/client/src/components/game/charts/ChartInfoFormat.tsx
+++ b/client/src/components/game/charts/ChartInfoFormat.tsx
@@ -61,23 +61,25 @@ export default function ChartInfoFormat({
 				justifyContent: "space-evenly",
 			}}
 		>
-			<Col xs={12} lg={3}>
+			<Col xs={12} lg={3} style={{ textAlign: "left" }}>
 				<h4>Appears In</h4>
 				{data.length !== 0 ? (
-					data.map((e) => (
-						<li key={e.folderID}>
-							{user && ugs ? (
-								<Link
-									className="text-decoration-none"
-									to={`/u/${user.username}/games/${game}/${playtype}/folders/${e.folderID}`}
-								>
-									{e.title}
-								</Link>
-							) : (
-								<span>{e.title}</span>
-							)}
-						</li>
-					))
+					data
+						.sort((a, b) => a.title.localeCompare(b.title))
+						.map((e) => (
+							<li key={e.folderID}>
+								{user && ugs ? (
+									<Link
+										className="text-decoration-none"
+										to={`/u/${user.username}/games/${game}/${playtype}/folders/${e.folderID}`}
+									>
+										{e.title}
+									</Link>
+								) : (
+									<span>{e.title}</span>
+								)}
+							</li>
+						))
 				) : (
 					<Muted>No folders...</Muted>
 				)}

--- a/client/src/components/game/charts/ChartInfoFormat.tsx
+++ b/client/src/components/game/charts/ChartInfoFormat.tsx
@@ -53,6 +53,8 @@ export default function ChartInfoFormat({
 		return <Loading />;
 	}
 
+	const versions = Object.keys(GetGamePTConfig(game, playtype).versions);
+
 	return (
 		<Row
 			className="text-center align-items-center"
@@ -66,6 +68,12 @@ export default function ChartInfoFormat({
 				{data.length !== 0 ? (
 					data
 						.sort((a, b) => a.title.localeCompare(b.title))
+						.sort((a, b) =>
+							"versions" in a.data && "versions" in b.data
+								? versions.indexOf(a.data.versions) -
+								  versions.indexOf(b.data.versions)
+								: 0
+						)
 						.map((e) => (
 							<li key={e.folderID}>
 								{user && ugs ? (


### PR DESCRIPTION
#1085 is going to make Tunism's folder lists even longer. This is an attempt to make them more readable
Version sort + lexical sort + left-align (center-align makes it chaotic)

Before:
![image](https://github.com/zkldi/Tachi/assets/61069237/ca36cfec-03d7-444f-b7f5-790996cf355f)

After:
![image](https://github.com/zkldi/Tachi/assets/61069237/b67b9e60-5208-4196-a1f1-08f050c3c8c6)
