### PR TITLE
add links to GAN and NAG in service integration page

### DIFF
--- a/client/src/app/pages/dashboard/users/UserIntegrationsPage.tsx
+++ b/client/src/app/pages/dashboard/users/UserIntegrationsPage.tsx
@@ -641,7 +641,8 @@ function ServicesPage({ reqUser }: { reqUser: UserDocument }) {
 			<Col xs={12}>
 				<div className="btn-group">
 					<SelectLinkButton to={`${baseUrl}/fervidex`}>Fervidex</SelectLinkButton>
-					<SelectLinkButton to={`${baseUrl}/cg`}>CG</SelectLinkButton>
+					<SelectLinkButton to={`${baseUrl}/cg-gan`}>CG GAN</SelectLinkButton>
+					<SelectLinkButton to={`${baseUrl}/cg-nag`}>CG NAG</SelectLinkButton>
 					<SelectLinkButton to={`${baseUrl}/cg-dev`}>CG Dev</SelectLinkButton>
 					<SelectLinkButton to={`${baseUrl}/myt`}>MYT</SelectLinkButton>
 					<SelectLinkButton to={`${baseUrl}/kshook`}>KsHook</SelectLinkButton>


### PR DESCRIPTION
This change is completely untested!!

I think this was meant to be here since GAN and NAG were split out, but somehow got missed. I just noticed it and it looks like an obvious fix. I did this in the github web editor so I have no clue if it works lol