### PR TITLE
feat: add casthour pack 2 songs to Infinitas

### DIFF
--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -20126,7 +20126,9 @@
 		"title": "Echo Of Forever"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"Reflection Into the EDEN"
+		],
 		"artist": "猫叉Master",
 		"data": {
 			"displayVersion": "20",


### PR DESCRIPTION
This marks all charts from the 2nd infinitas casthour pack as available in inf, [songlist here](https://p.eagate.573.jp/game/infinitas/2/music/index.html#pac)

It also includes the fixes for Reflection into the EDEN and Strong Jaeger from PR 1045.