### PR TITLE
feat: make the duplicate-song-title-checker work

### DIFF
--- a/common/src/types/documents.ts
+++ b/common/src/types/documents.ts
@@ -514,6 +514,15 @@ export interface ImportProcessInfoInvalidDatapoint {
 	content: Record<string, never>;
 }
 
+export interface ImportProcessInfoAmbiguousTitle {
+	success: false;
+	type: "AmbiguousTitle";
+	message: string;
+	content: {
+		title: string;
+	};
+}
+
 export interface ImportProcessInfoScoreImported<GPT extends GPTString = GPTString> {
 	success: true;
 	type: "ScoreImported";
@@ -543,6 +552,7 @@ export interface ImportProcessInfoSongOrChartNotFound {
 }
 
 export type ImportProcessingInfo<GPT extends GPTString = GPTString> =
+	| ImportProcessInfoAmbiguousTitle
 	| ImportProcessInfoInternalError
 	| ImportProcessInfoInvalidDatapoint
 	| ImportProcessInfoOrphanExists

--- a/database-seeds/collections/songs-chunithm.json
+++ b/database-seeds/collections/songs-chunithm.json
@@ -7924,17 +7924,6 @@
 	},
 	{
 		"altTitles": [],
-		"artist": "BUMP OF CHICKEN「グランブルーファンタジー」",
-		"data": {
-			"displayVersion": "amazonplus",
-			"genre": "POPS & ANIME"
-		},
-		"id": 723,
-		"searchTerms": [],
-		"title": "GO"
-	},
-	{
-		"altTitles": [],
 		"artist": "ジータ（CV:金元寿子）、ルリア（CV:東山奈央）、ヴィーラ（CV:今井麻美）、マリー（CV:長谷川明子）「グランブルーファンタジー」",
 		"data": {
 			"displayVersion": "amazonplus",

--- a/database-seeds/collections/songs-chunithm.json
+++ b/database-seeds/collections/songs-chunithm.json
@@ -7924,6 +7924,17 @@
 	},
 	{
 		"altTitles": [],
+		"artist": "BUMP OF CHICKEN「グランブルーファンタジー」",
+		"data": {
+			"displayVersion": "amazonplus",
+			"genre": "POPS & ANIME"
+		},
+		"id": 723,
+		"searchTerms": [],
+		"title": "GO"
+	},
+	{
+		"altTitles": [],
 		"artist": "ジータ（CV:金元寿子）、ルリア（CV:東山奈央）、ヴィーラ（CV:今井麻美）、マリー（CV:長谷川明子）「グランブルーファンタジー」",
 		"data": {
 			"displayVersion": "amazonplus",

--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -2404,8 +2404,7 @@
 	},
 	{
 		"altTitles": [
-			"Theme Of Denjin J",
-			"電人イェーガーのテーマ(Theme of DENJIN J)"
+			"Theme Of Denjin J"
 		],
 		"artist": "L.E.D.",
 		"data": {
@@ -9815,7 +9814,6 @@
 	{
 		"altTitles": [
 			"Raison d'&ecirc;tre〜交差する宿命〜",
-			"Raison d'être～交差する宿命～",
 			"Raison d'etre～交差する宿命～",
 			"Raison d'?tre～交差する宿命～",
 			"Raison d'être〜交差する宿命〜"
@@ -12520,7 +12518,6 @@
 	{
 		"altTitles": [
 			"キャトられ♥恋はモ〜モク",
-			"キャトられ♥恋はモ～モク",
 			"キャトられ恋はモ～モク",
 			"キャトられ❤恋はモ〜モク",
 			"キャトられ?恋はモ～モク"
@@ -13226,8 +13223,6 @@
 		"altTitles": [
 			"旋律のドグマ〜Misérables〜",
 			"旋律のドグマ〜Misérables〜",
-			"旋律のドグマ～Misérables～",
-			"旋律のドグマ～Misérables～",
 			"旋律のドグマ～Miserables～",
 			"旋律のドグマ ～Misérables～",
 			"旋律のドグマ～Mis?rables～"

--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -1795,7 +1795,6 @@
 	{
 		"altTitles": [
 			"RIDE ON THE LIGHT (HI GREAT MIX) †",
-			"RIDE ON THE LIGHT (HI GREAT MIX) †",
 			"RIDE ON THE LIGHT (HI GREAT MIX) "
 		],
 		"artist": "Mr.T",
@@ -2096,7 +2095,6 @@
 	},
 	{
 		"altTitles": [
-			"BALLAD FOR YOU〜想いの雨〜",
 			"BALLAD FOR YOU〜想いの雨〜",
 			"Ballad For You"
 		],
@@ -12923,7 +12921,6 @@
 	},
 	{
 		"altTitles": [
-			"†渚の小悪魔ラヴリィ〜レイディオ†(IIDX EDIT)",
 			"†渚の小悪魔ラヴリィ〜レイディオ†(IIDX EDIT)"
 		],
 		"artist": "夏色ビキニのPrim",
@@ -13221,7 +13218,6 @@
 	},
 	{
 		"altTitles": [
-			"旋律のドグマ〜Misérables〜",
 			"旋律のドグマ〜Misérables〜",
 			"旋律のドグマ～Miserables～",
 			"旋律のドグマ ～Misérables～",

--- a/database-seeds/collections/songs-maimai.json
+++ b/database-seeds/collections/songs-maimai.json
@@ -1,8 +1,6 @@
 [
 	{
-		"altTitles": [
-			"True Love Song"
-		],
+		"altTitles": [],
 		"artist": "Kai/classical “Air on the G String”",
 		"data": {
 			"artistJP": "Kai/クラシック「G線上のアリア」",
@@ -14,9 +12,7 @@
 		"title": "True Love Song"
 	},
 	{
-		"altTitles": [
-			"Color My World"
-		],
+		"altTitles": [],
 		"artist": "GOSH/classical “Pathetique”",
 		"data": {
 			"artistJP": "GOSH/クラシック「悲愴」",
@@ -28,9 +24,7 @@
 		"title": "Color My World"
 	},
 	{
-		"altTitles": [
-			"Future"
-		],
+		"altTitles": [],
 		"artist": "★STAR GUiTAR [cover]",
 		"data": {
 			"artistJP": "★STAR GUiTAR [cover]",
@@ -42,9 +36,7 @@
 		"title": "Future"
 	},
 	{
-		"altTitles": [
-			"Love You"
-		],
+		"altTitles": [],
 		"artist": "Q;indivi [cover]",
 		"data": {
 			"artistJP": "Q;indivi [cover]",
@@ -70,9 +62,7 @@
 		"title": "connect"
 	},
 	{
-		"altTitles": [
-			"In Chaos"
-		],
+		"altTitles": [],
 		"artist": "Hiro “Crackin’DJ”",
 		"data": {
 			"artistJP": "Hiro「Crackin’DJ」",
@@ -84,9 +74,7 @@
 		"title": "In Chaos"
 	},
 	{
-		"altTitles": [
-			"Crush On You"
-		],
+		"altTitles": [],
 		"artist": "Fukuyama mitsuharu “Crackin’DJ”",
 		"data": {
 			"artistJP": "福山光晴「Crackin’DJ」",
@@ -98,9 +86,7 @@
 		"title": "Crush On You"
 	},
 	{
-		"altTitles": [
-			"Sun Dance"
-		],
+		"altTitles": [],
 		"artist": "Hiro “Crackin’DJ”",
 		"data": {
 			"artistJP": "Hiro「Crackin’DJ」",
@@ -112,9 +98,7 @@
 		"title": "Sun Dance"
 	},
 	{
-		"altTitles": [
-			"Sweets×Sweets"
-		],
+		"altTitles": [],
 		"artist": "Team-D",
 		"data": {
 			"artistJP": "Team-D",
@@ -182,9 +166,7 @@
 		"title": "The★Tanko★Bushi"
 	},
 	{
-		"altTitles": [
-			"NIGHT OF FIRE"
-		],
+		"altTitles": [],
 		"artist": "NIKO [cover]",
 		"data": {
 			"artistJP": "NIKO [cover]",
@@ -196,9 +178,7 @@
 		"title": "NIGHT OF FIRE"
 	},
 	{
-		"altTitles": [
-			"come again"
-		],
+		"altTitles": [],
 		"artist": "m-flo [cover]",
 		"data": {
 			"artistJP": "m-flo [cover]",
@@ -210,9 +190,7 @@
 		"title": "come again"
 	},
 	{
-		"altTitles": [
-			"jelly"
-		],
+		"altTitles": [],
 		"artist": "capsule [cover]",
 		"data": {
 			"artistJP": "capsule [cover]",
@@ -294,9 +272,7 @@
 		"title": "caramelldansen"
 	},
 	{
-		"altTitles": [
-			"Endless World"
-		],
+		"altTitles": [],
 		"artist": "RYOHEI KOHNO/Miwako Hotate",
 		"data": {
 			"artistJP": "RYOHEI KOHNO/保立美和子",
@@ -308,9 +284,7 @@
 		"title": "Endless World"
 	},
 	{
-		"altTitles": [
-			"Beat Of Mind"
-		],
+		"altTitles": [],
 		"artist": "Hiro “Crackin’DJ”",
 		"data": {
 			"artistJP": "Hiro「Crackin’DJ」",
@@ -364,9 +338,7 @@
 		"title": "Teach Me Magical Lyrics!"
 	},
 	{
-		"altTitles": [
-			"ZIGG-ZAGG"
-		],
+		"altTitles": [],
 		"artist": "Junky",
 		"data": {
 			"artistJP": "Junky",
@@ -546,9 +518,7 @@
 		"title": "Showtime"
 	},
 	{
-		"altTitles": [
-			"City Escape: Act1"
-		],
+		"altTitles": [],
 		"artist": "Cash Cash “Sonic Generations”",
 		"data": {
 			"artistJP": "Cash Cash「ソニック ジェネレーションズ」",
@@ -560,9 +530,7 @@
 		"title": "City Escape: Act1"
 	},
 	{
-		"altTitles": [
-			"Rooftop Run: Act1"
-		],
+		"altTitles": [],
 		"artist": "Tomoya Ohtani “Sonic Generations”",
 		"data": {
 			"artistJP": "大谷智哉「ソニック ジェネレーションズ」",
@@ -574,9 +542,7 @@
 		"title": "Rooftop Run: Act1"
 	},
 	{
-		"altTitles": [
-			"Reach For The Stars"
-		],
+		"altTitles": [],
 		"artist": "Tomoya Ohtani, Jean Paul Makhlouf of Cash Cash “Sonic Colors”",
 		"data": {
 			"artistJP": "大谷智哉, Jean Paul Makhlouf of Cash Cash「ソニック カラーズ」",
@@ -588,9 +554,7 @@
 		"title": "Reach For The Stars"
 	},
 	{
-		"altTitles": [
-			"Urban Crusher [Remix]"
-		],
+		"altTitles": [],
 		"artist": "“BORDER BREAK”",
 		"data": {
 			"artistJP": "「BORDER BREAK」",
@@ -602,9 +566,7 @@
 		"title": "Urban Crusher [Remix]"
 	},
 	{
-		"altTitles": [
-			"Catch The Future"
-		],
+		"altTitles": [],
 		"artist": "“BORDER BREAK UNION”",
 		"data": {
 			"artistJP": "「BORDER BREAK UNION」メインテーマ",
@@ -616,9 +578,7 @@
 		"title": "Catch The Future"
 	},
 	{
-		"altTitles": [
-			"JACKY [Remix]"
-		],
+		"altTitles": [],
 		"artist": "“Virtua Fighter”",
 		"data": {
 			"artistJP": "「バーチャファイター」",
@@ -630,9 +590,7 @@
 		"title": "JACKY [Remix]"
 	},
 	{
-		"altTitles": [
-			"Tell Your World"
-		],
+		"altTitles": [],
 		"artist": "livetune",
 		"data": {
 			"artistJP": "livetune",
@@ -672,9 +630,7 @@
 		"title": "Dancing☆Samurai"
 	},
 	{
-		"altTitles": [
-			"BAD∞END∞NIGHT"
-		],
+		"altTitles": [],
 		"artist": "Hitoshizuku×Yama△",
 		"data": {
 			"artistJP": "ひとしずくP・やま△",
@@ -700,9 +656,7 @@
 		"title": "Romeo and Cinderella"
 	},
 	{
-		"altTitles": [
-			"Sweetiex2"
-		],
+		"altTitles": [],
 		"artist": "Dixie Flatline",
 		"data": {
 			"artistJP": "Dixie Flatline",
@@ -728,9 +682,7 @@
 		"title": "Kusare gedou to chocolate"
 	},
 	{
-		"altTitles": [
-			"Quartet Theme [Reborn]"
-		],
+		"altTitles": [],
 		"artist": "COSIO(ZUNTATA/TAITO)“QUARTET”",
 		"data": {
 			"artistJP": "COSIO(ZUNTATA/TAITO)「カルテット」",
@@ -742,9 +694,7 @@
 		"title": "Quartet Theme [Reborn]"
 	},
 	{
-		"altTitles": [
-			"Sky High [Reborn]"
-		],
+		"altTitles": [],
 		"artist": "Hiroshi Okubo(BNGI)“DAYTONA USA”",
 		"data": {
 			"artistJP": "大久保 博(BNGI)「デイトナ USA」",
@@ -756,9 +706,7 @@
 		"title": "Sky High [Reborn]"
 	},
 	{
-		"altTitles": [
-			"Like the Wind [Reborn]"
-		],
+		"altTitles": [],
 		"artist": "sampling masters MEGA “POWER DRIFT”",
 		"data": {
 			"artistJP": "sampling masters MEGA「パワードリフト」",
@@ -770,9 +718,7 @@
 		"title": "Like the Wind [Reborn]"
 	},
 	{
-		"altTitles": [
-			"YA･DA･YO [Reborn]"
-		],
+		"altTitles": [],
 		"artist": "Yuzo Koshiro “FANTASY ZONE”",
 		"data": {
 			"artistJP": "古代 祐三「ファンタジーゾーン」",
@@ -784,9 +730,7 @@
 		"title": "YA･DA･YO [Reborn]"
 	},
 	{
-		"altTitles": [
-			"Space Harrier Main Theme [Reborn]"
-		],
+		"altTitles": [],
 		"artist": "sanodg “SPACE HARRIER”",
 		"data": {
 			"artistJP": "佐野 信義「スペースハリアー」",
@@ -798,9 +742,7 @@
 		"title": "Space Harrier Main Theme [Reborn]"
 	},
 	{
-		"altTitles": [
-			"DADDY MULK -Groove remix-"
-		],
+		"altTitles": [],
 		"artist": "Performed by SEGA Sound Unit [H.]",
 		"data": {
 			"artistJP": "Performed by SEGA Sound Unit [H.]",
@@ -938,9 +880,7 @@
 		"title": "Mihata no motoni"
 	},
 	{
-		"altTitles": [
-			"FEEL ALIVE"
-		],
+		"altTitles": [],
 		"artist": "ELEMENTAS feat. NAGISA",
 		"data": {
 			"artistJP": "ELEMENTAS feat. NAGISA",
@@ -952,9 +892,7 @@
 		"title": "FEEL ALIVE"
 	},
 	{
-		"altTitles": [
-			"Link"
-		],
+		"altTitles": [],
 		"artist": "Clean Tears feat. Youna",
 		"data": {
 			"artistJP": "Clean Tears feat. Youna",
@@ -966,9 +904,7 @@
 		"title": "Link"
 	},
 	{
-		"altTitles": [
-			"Turn around"
-		],
+		"altTitles": [],
 		"artist": "Clean Tears",
 		"data": {
 			"artistJP": "Clean Tears",
@@ -980,9 +916,7 @@
 		"title": "Turn around"
 	},
 	{
-		"altTitles": [
-			"We Gonna Party"
-		],
+		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
 			"artistJP": "Cranky",
@@ -994,9 +928,7 @@
 		"title": "We Gonna Party"
 	},
 	{
-		"altTitles": [
-			"Night Fly"
-		],
+		"altTitles": [],
 		"artist": "Hatsunetsumiko's",
 		"data": {
 			"artistJP": "発熱巫女〜ず",
@@ -1008,9 +940,7 @@
 		"title": "Night Fly"
 	},
 	{
-		"altTitles": [
-			"Feel My Fire"
-		],
+		"altTitles": [],
 		"artist": "Hatsunetsumiko's",
 		"data": {
 			"artistJP": "発熱巫女〜ず",
@@ -1022,9 +952,7 @@
 		"title": "Feel My Fire"
 	},
 	{
-		"altTitles": [
-			"Streak"
-		],
+		"altTitles": [],
 		"artist": "ARM(IOSYS)",
 		"data": {
 			"artistJP": "ARM(IOSYS)",
@@ -1036,9 +964,7 @@
 		"title": "Streak"
 	},
 	{
-		"altTitles": [
-			"Spin me harder"
-		],
+		"altTitles": [],
 		"artist": "D.watt(IOSYS)feat. Asana",
 		"data": {
 			"artistJP": "D.watt(IOSYS)feat. Asana",
@@ -1050,9 +976,7 @@
 		"title": "Spin me harder"
 	},
 	{
-		"altTitles": [
-			"Lionheart"
-		],
+		"altTitles": [],
 		"artist": "Masayoshi Minoshima",
 		"data": {
 			"artistJP": "Masayoshi Minoshima",
@@ -1064,9 +988,7 @@
 		"title": "Lionheart"
 	},
 	{
-		"altTitles": [
-			"Acceleration"
-		],
+		"altTitles": [],
 		"artist": "REDALiCE",
 		"data": {
 			"artistJP": "REDALiCE",
@@ -1078,9 +1000,7 @@
 		"title": "Acceleration"
 	},
 	{
-		"altTitles": [
-			"Sprintrances"
-		],
+		"altTitles": [],
 		"artist": "Taishi",
 		"data": {
 			"artistJP": "Taishi",
@@ -1092,9 +1012,7 @@
 		"title": "Sprintrances"
 	},
 	{
-		"altTitles": [
-			"Nerverakes"
-		],
+		"altTitles": [],
 		"artist": "Taishi",
 		"data": {
 			"artistJP": "Taishi",
@@ -1106,9 +1024,7 @@
 		"title": "Nerverakes"
 	},
 	{
-		"altTitles": [
-			"Black Out"
-		],
+		"altTitles": [],
 		"artist": "Tsukasa(Arte Refact)",
 		"data": {
 			"artistJP": "Tsukasa(Arte Refact)",
@@ -1120,9 +1036,7 @@
 		"title": "Black Out"
 	},
 	{
-		"altTitles": [
-			"Fragrance"
-		],
+		"altTitles": [],
 		"artist": "Tsukasa(Arte Refact)",
 		"data": {
 			"artistJP": "Tsukasa(Arte Refact)",
@@ -1134,9 +1048,7 @@
 		"title": "Fragrance"
 	},
 	{
-		"altTitles": [
-			"air's gravity"
-		],
+		"altTitles": [],
 		"artist": "zts",
 		"data": {
 			"artistJP": "zts",
@@ -1148,9 +1060,7 @@
 		"title": "air's gravity"
 	},
 	{
-		"altTitles": [
-			"Starlight Disco"
-		],
+		"altTitles": [],
 		"artist": "loos feat. Meramipop",
 		"data": {
 			"artistJP": "loos feat. Meramipop",
@@ -1162,9 +1072,7 @@
 		"title": "Starlight Disco"
 	},
 	{
-		"altTitles": [
-			"39"
-		],
+		"altTitles": [],
 		"artist": "sasakure.UK x DECO*27",
 		"data": {
 			"artistJP": "sasakure.UK x DECO*27",
@@ -1218,9 +1126,7 @@
 		"title": "Power of order"
 	},
 	{
-		"altTitles": [
-			"DO RORO DERODERO ON DO RORO"
-		],
+		"altTitles": [],
 		"artist": "Dohatsuten “Mononoke Bloodshow”",
 		"data": {
 			"artistJP": "怒髪天「百鬼大戦絵巻」",
@@ -1246,9 +1152,7 @@
 		"title": "NAKIMUSHI O'clock"
 	},
 	{
-		"altTitles": [
-			"Natural Flow"
-		],
+		"altTitles": [],
 		"artist": "KENTARO “Crackin’DJ”",
 		"data": {
 			"artistJP": "KENTARO「Crackin’DJ」",
@@ -1288,9 +1192,7 @@
 		"title": "Kimi no Shiranai Monogatari"
 	},
 	{
-		"altTitles": [
-			"I ♥"
-		],
+		"altTitles": [],
 		"artist": "Junky",
 		"data": {
 			"artistJP": "Junky",
@@ -1400,9 +1302,7 @@
 		"title": "nou shou sakuretsu girl"
 	},
 	{
-		"altTitles": [
-			"SPiCa"
-		],
+		"altTitles": [],
 		"artist": "tokuP",
 		"data": {
 			"artistJP": "とくP",
@@ -1470,9 +1370,7 @@
 		"title": "Cirno's Perfect Math Class"
 	},
 	{
-		"altTitles": [
-			"Bad Apple!! feat nomico"
-		],
+		"altTitles": [],
 		"artist": "Masayoshi Minoshima",
 		"data": {
 			"artistJP": "Masayoshi Minoshima",
@@ -1498,9 +1396,7 @@
 		"title": "Marisa Stole the Precious Thing"
 	},
 	{
-		"altTitles": [
-			"Grip & Break down !!"
-		],
+		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"artistJP": "SOUND HOLIC feat. Nana Takahashi",
@@ -1512,9 +1408,7 @@
 		"title": "Grip & Break down !!"
 	},
 	{
-		"altTitles": [
-			"Help me, ERINNNNNN!!"
-		],
+		"altTitles": [],
 		"artist": "beatMARIO(COOL＆CREATE)",
 		"data": {
 			"artistJP": "ビートまりお(COOL＆CREATE)",
@@ -1582,9 +1476,7 @@
 		"title": "Jikuu Wo Koete Hisashiburi!"
 	},
 	{
-		"altTitles": [
-			"Her Dream Is To Be A Fantastic Sorceress"
-		],
+		"altTitles": [],
 		"artist": "Amitie/Shiho Kikuchi“PUYOPUYO”",
 		"data": {
 			"artistJP": "アミティ(CV 菊池志穂)「ぷよぷよ」",
@@ -1638,9 +1530,7 @@
 		"title": "KONNAN-jyanai!"
 	},
 	{
-		"altTitles": [
-			"awake"
-		],
+		"altTitles": [],
 		"artist": "Asami Shimoda“Shining・Force CROSS ELYSION”",
 		"data": {
 			"artistJP": "下田麻美「Shining・Force CROSS ELYSION」",
@@ -1652,9 +1542,7 @@
 		"title": "awake"
 	},
 	{
-		"altTitles": [
-			"Mysterious Destiny"
-		],
+		"altTitles": [],
 		"artist": "“BAYONETTA”",
 		"data": {
 			"artistJP": "「BAYONETTA(ベヨネッタ)」",
@@ -1666,9 +1554,7 @@
 		"title": "Mysterious Destiny"
 	},
 	{
-		"altTitles": [
-			"Riders Of The Light"
-		],
+		"altTitles": [],
 		"artist": "“BAYONETTA”",
 		"data": {
 			"artistJP": "「BAYONETTA(ベヨネッタ)」",
@@ -1680,9 +1566,7 @@
 		"title": "Riders Of The Light"
 	},
 	{
-		"altTitles": [
-			"Terminal Storm"
-		],
+		"altTitles": [],
 		"artist": "Kojiro Mikusa“CODE OF JOKER”",
 		"data": {
 			"artistJP": "三草康二郎「CODE OF JOKER」",
@@ -1750,9 +1634,7 @@
 		"title": "USATEI"
 	},
 	{
-		"altTitles": [
-			"sweet little sister"
-		],
+		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
 			"artistJP": "Silver Forest",
@@ -1764,9 +1646,7 @@
 		"title": "sweet little sister"
 	},
 	{
-		"altTitles": [
-			"Blew Moon"
-		],
+		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
 			"artistJP": "t+pazolite",
@@ -1778,9 +1658,7 @@
 		"title": "Blew Moon"
 	},
 	{
-		"altTitles": [
-			"Garakuta Doll Play"
-		],
+		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
 			"artistJP": "t+pazolite",
@@ -1792,9 +1670,7 @@
 		"title": "Garakuta Doll Play"
 	},
 	{
-		"altTitles": [
-			"Dreampainter"
-		],
+		"altTitles": [],
 		"artist": "Sta feat.tigerlily and DOT96",
 		"data": {
 			"artistJP": "Sta feat.tigerlily and DOT96",
@@ -1820,9 +1696,7 @@
 		"title": "Coinlaundry Disco"
 	},
 	{
-		"altTitles": [
-			"CYCLES"
-		],
+		"altTitles": [],
 		"artist": "Masayoshi Minoshima feat. Mei Ayakura",
 		"data": {
 			"artistJP": "Masayoshi Minoshima feat. 綾倉盟",
@@ -1834,9 +1708,7 @@
 		"title": "CYCLES"
 	},
 	{
-		"altTitles": [
-			"Heartbeats"
-		],
+		"altTitles": [],
 		"artist": "RAMM feat. Yuki Wakai",
 		"data": {
 			"artistJP": "RAMM feat. 若井友希",
@@ -1848,9 +1720,7 @@
 		"title": "Heartbeats"
 	},
 	{
-		"altTitles": [
-			"Life Feels Good"
-		],
+		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
 			"artistJP": "Cranky",
@@ -1862,9 +1732,7 @@
 		"title": "Life Feels Good"
 	},
 	{
-		"altTitles": [
-			"MYTHOS"
-		],
+		"altTitles": [],
 		"artist": "Cranky feat. Marasy ＆ Teppei",
 		"data": {
 			"artistJP": "Cranky feat. まらしぃ ＆ てっぺい先生",
@@ -1876,9 +1744,7 @@
 		"title": "MYTHOS"
 	},
 	{
-		"altTitles": [
-			"End of Twilight"
-		],
+		"altTitles": [],
 		"artist": "ALiCE'S EMOTiON feat. Ayumi Nomiya",
 		"data": {
 			"artistJP": "ALiCE'S EMOTiON feat. Ayumi Nomiya",
@@ -1918,9 +1784,7 @@
 		"title": "YUBIKIRI"
 	},
 	{
-		"altTitles": [
-			"Pixel Voyage"
-		],
+		"altTitles": [],
 		"artist": "YMCK",
 		"data": {
 			"artistJP": "YMCK",
@@ -1932,9 +1796,7 @@
 		"title": "Pixel Voyage"
 	},
 	{
-		"altTitles": [
-			"Get Happy"
-		],
+		"altTitles": [],
 		"artist": "Jimmy Weckl",
 		"data": {
 			"artistJP": "Jimmy Weckl",
@@ -1946,9 +1808,7 @@
 		"title": "Get Happy"
 	},
 	{
-		"altTitles": [
-			"System “Z”"
-		],
+		"altTitles": [],
 		"artist": "Jimmy Weckl",
 		"data": {
 			"artistJP": "Jimmy Weckl",
@@ -1960,9 +1820,7 @@
 		"title": "System “Z”"
 	},
 	{
-		"altTitles": [
-			"Beat of getting entangled"
-		],
+		"altTitles": [],
 		"artist": "Shoichiro Hirata",
 		"data": {
 			"artistJP": "Shoichiro Hirata",
@@ -1974,9 +1832,7 @@
 		"title": "Beat of getting entangled"
 	},
 	{
-		"altTitles": [
-			"Cosmic Train"
-		],
+		"altTitles": [],
 		"artist": "Shoichiro Hirata feat.SUIMI",
 		"data": {
 			"artistJP": "Shoichiro Hirata feat.SUIMI",
@@ -2030,9 +1886,7 @@
 		"title": "mayim mayim feat. Weekly Shonen Magazine"
 	},
 	{
-		"altTitles": [
-			"Danza zandA"
-		],
+		"altTitles": [],
 		"artist": "Fukuyama mitsuharu",
 		"data": {
 			"artistJP": "福山光晴",
@@ -2058,9 +1912,7 @@
 		"title": "BAD GIRL"
 	},
 	{
-		"altTitles": [
-			"Monochrome Rainbow"
-		],
+		"altTitles": [],
 		"artist": "Sta",
 		"data": {
 			"artistJP": "Sta",
@@ -2100,9 +1952,7 @@
 		"title": "Enbukyoku Kimini"
 	},
 	{
-		"altTitles": [
-			"Live & Learn"
-		],
+		"altTitles": [],
 		"artist": "Crush 40 “Sonic Adventure 2”",
 		"data": {
 			"artistJP": "Crush 40「ソニックアドベンチャー2」",
@@ -2142,9 +1992,7 @@
 		"title": "iarufanclub"
 	},
 	{
-		"altTitles": [
-			"Nyan Cat EX"
-		],
+		"altTitles": [],
 		"artist": "daniwell",
 		"data": {
 			"artistJP": "daniwell",
@@ -2170,9 +2018,7 @@
 		"title": "POPIPO"
 	},
 	{
-		"altTitles": [
-			"LUCIA"
-		],
+		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
 			"artistJP": "SHIKI",
@@ -2184,9 +2030,7 @@
 		"title": "LUCIA"
 	},
 	{
-		"altTitles": [
-			"Death Scythe"
-		],
+		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
 			"artistJP": "SHIKI",
@@ -2198,9 +2042,7 @@
 		"title": "Death Scythe"
 	},
 	{
-		"altTitles": [
-			"BREAK YOU!!"
-		],
+		"altTitles": [],
 		"artist": "A-One",
 		"data": {
 			"artistJP": "A-One",
@@ -2212,9 +2054,7 @@
 		"title": "BREAK YOU!!"
 	},
 	{
-		"altTitles": [
-			"JUMPIN' JUMPIN'"
-		],
+		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"artistJP": "SOUND HOLIC feat. Nana Takahashi",
@@ -2226,9 +2066,7 @@
 		"title": "JUMPIN' JUMPIN'"
 	},
 	{
-		"altTitles": [
-			"L'épilogue"
-		],
+		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"artistJP": "SOUND HOLIC feat. Nana Takahashi",
@@ -2240,9 +2078,7 @@
 		"title": "L'épilogue"
 	},
 	{
-		"altTitles": [
-			"Save This World νMIX"
-		],
+		"altTitles": [],
 		"artist": "“PHANTASY STAR PORTABLE”",
 		"data": {
 			"artistJP": "「PHANTASY STAR PORTABLE」",
@@ -2254,9 +2090,7 @@
 		"title": "Save This World νMIX"
 	},
 	{
-		"altTitles": [
-			"Living Universe"
-		],
+		"altTitles": [],
 		"artist": "“PHANTASY STAR PORTABLE2”",
 		"data": {
 			"artistJP": "「PHANTASY STAR PORTABLE2」",
@@ -2268,9 +2102,7 @@
 		"title": "Living Universe"
 	},
 	{
-		"altTitles": [
-			"Ignite Infinity"
-		],
+		"altTitles": [],
 		"artist": "“PHANTASY STAR PORTABLE2 ∞”",
 		"data": {
 			"artistJP": "「PHANTASY STAR PORTABLE2 ∞」",
@@ -2310,9 +2142,7 @@
 		"title": "Uraomote Lovers"
 	},
 	{
-		"altTitles": [
-			"Outlaw's Lullaby"
-		],
+		"altTitles": [],
 		"artist": "“Yakuza2”",
 		"data": {
 			"artistJP": "「龍が如く２」",
@@ -2324,9 +2154,7 @@
 		"title": "Outlaw's Lullaby"
 	},
 	{
-		"altTitles": [
-			"Brand-new Japanesque"
-		],
+		"altTitles": [],
 		"artist": "“Ryu Ga Gotoku Kenzan!”",
 		"data": {
 			"artistJP": "「龍が如く 見参！」",
@@ -2422,9 +2250,7 @@
 		"title": "Mukashi Mukashi no Kyou no Boku"
 	},
 	{
-		"altTitles": [
-			"magician's operation"
-		],
+		"altTitles": [],
 		"artist": "EZFG",
 		"data": {
 			"artistJP": "EZFG",
@@ -2492,9 +2318,7 @@
 		"title": "Haro／Hawayu"
 	},
 	{
-		"altTitles": [
-			"Our Fighting"
-		],
+		"altTitles": [],
 		"artist": "Quna(CV Eri Kitamura)“PHANTASY STAR ONLINE 2”",
 		"data": {
 			"artistJP": "クーナ(CV 喜多村英梨)「PHANTASY STAR ONLINE 2」",
@@ -2534,9 +2358,7 @@
 		"title": "akeboshi rocket"
 	},
 	{
-		"altTitles": [
-			"The Great Journey"
-		],
+		"altTitles": [],
 		"artist": "Takenobu Mitsuyoshi “HORUKA × TORUKA”",
 		"data": {
 			"artistJP": "光吉猛修「ホルカ・トルカ」",
@@ -2576,9 +2398,7 @@
 		"title": "The Lamentations of the Lost Ones"
 	},
 	{
-		"altTitles": [
-			"Sweet Devil"
-		],
+		"altTitles": [],
 		"artist": "8＃Prince",
 		"data": {
 			"artistJP": "八王子P",
@@ -2618,9 +2438,7 @@
 		"title": "kero9destiny"
 	},
 	{
-		"altTitles": [
-			"Endless, Sleepless Night"
-		],
+		"altTitles": [],
 		"artist": "samfree feat.kanipan(A-ONE)",
 		"data": {
 			"artistJP": "samfree feat.(V)・∀・(V)かにぱん。(A-ONE)",
@@ -2632,9 +2450,7 @@
 		"title": "Endless, Sleepless Night"
 	},
 	{
-		"altTitles": [
-			"POP STAR"
-		],
+		"altTitles": [],
 		"artist": "Ken Hirai [cover]",
 		"data": {
 			"artistJP": "平井堅 [cover]",
@@ -2646,9 +2462,7 @@
 		"title": "POP STAR"
 	},
 	{
-		"altTitles": [
-			"Back 2 Back"
-		],
+		"altTitles": [],
 		"artist": "Hideki Naganuma “Sonic Rush”",
 		"data": {
 			"artistJP": "長沼英樹「ソニック ラッシュ」",
@@ -2730,9 +2544,7 @@
 		"title": "machibitohakozu"
 	},
 	{
-		"altTitles": [
-			"Cosmic Magic Shooter"
-		],
+		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"artistJP": "SOUND HOLIC feat. Nana Takahashi",
@@ -2758,9 +2570,7 @@
 		"title": "Deep-Sea Girl"
 	},
 	{
-		"altTitles": [
-			"M.S.S.Planet"
-		],
+		"altTitles": [],
 		"artist": "M.S.S Project",
 		"data": {
 			"artistJP": "M.S.S Project",
@@ -2842,9 +2652,7 @@
 		"title": "Ringo Karenka"
 	},
 	{
-		"altTitles": [
-			"YATTA!"
-		],
+		"altTitles": [],
 		"artist": "Happa-tai [cover]",
 		"data": {
 			"artistJP": "はっぱ隊 [cover]",
@@ -2856,9 +2664,7 @@
 		"title": "YATTA!"
 	},
 	{
-		"altTitles": [
-			"Jack-the-Ripper◆"
-		],
+		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
 			"artistJP": "sasakure.UK",
@@ -2870,9 +2676,7 @@
 		"title": "Jack-the-Ripper◆"
 	},
 	{
-		"altTitles": [
-			"Windy Hill -Zone 1"
-		],
+		"altTitles": [],
 		"artist": "Tomoya Ohtani “Sonic Lost World”",
 		"data": {
 			"artistJP": "大谷智哉「ソニック ロストワールド」",
@@ -2954,9 +2758,7 @@
 		"title": "Chain story"
 	},
 	{
-		"altTitles": [
-			"Heart Beats"
-		],
+		"altTitles": [],
 		"artist": "himawari × emon(Tes.)",
 		"data": {
 			"artistJP": "向日葵×emon(Tes.)",
@@ -3010,9 +2812,7 @@
 		"title": "KODOU - move on -"
 	},
 	{
-		"altTitles": [
-			"DRAGONLADY"
-		],
+		"altTitles": [],
 		"artist": "Nankumo/CUBE3",
 		"data": {
 			"artistJP": "Nankumo/CUBE3",
@@ -3066,9 +2866,7 @@
 		"title": "Densha de Densha de GO!GO!GO!GC! -GMT remix-"
 	},
 	{
-		"altTitles": [
-			"RIDGE RACER STEPS -GMT remix-"
-		],
+		"altTitles": [],
 		"artist": "Yuji Masubuchi(BNGI)“RIDGE RACER”",
 		"data": {
 			"artistJP": "Yuji Masubuchi(BNGI)「RIDGE RACER」",
@@ -3122,9 +2920,7 @@
 		"title": "Densha de Densha de OPA!OPA!OPA! -GMT mashup-"
 	},
 	{
-		"altTitles": [
-			"Axeria"
-		],
+		"altTitles": [],
 		"artist": "AcuticNotes",
 		"data": {
 			"artistJP": "AcuticNotes",
@@ -3150,9 +2946,7 @@
 		"title": "Piiman Tabetara"
 	},
 	{
-		"altTitles": [
-			"MIRROR of MAGIC"
-		],
+		"altTitles": [],
 		"artist": "Shoichiro Hirata feat.SUIMI",
 		"data": {
 			"artistJP": "Shoichiro Hirata feat.SUIMI",
@@ -3178,9 +2972,7 @@
 		"title": "Yakiniku Restaurant! Orin's Jigokutei!"
 	},
 	{
-		"altTitles": [
-			"shake it!"
-		],
+		"altTitles": [],
 		"artist": "emon",
 		"data": {
 			"artistJP": "emon",
@@ -3220,9 +3012,7 @@
 		"title": "DOKUSENYOKU"
 	},
 	{
-		"altTitles": [
-			"YU-MU"
-		],
+		"altTitles": [],
 		"artist": "kisida kyoudan &The akeboshi rockets",
 		"data": {
 			"artistJP": "岸田教団＆THE明星ロケッツ",
@@ -3248,9 +3038,7 @@
 		"title": "Monosugoi Ikioide Ke-ne  ga Sugoi Uta"
 	},
 	{
-		"altTitles": [
-			"BETTER CHOICE"
-		],
+		"altTitles": [],
 		"artist": "Jimmy Weckl feat.Mina Takagi",
 		"data": {
 			"artistJP": "Jimmy Weckl feat.高貴みな",
@@ -3262,9 +3050,7 @@
 		"title": "BETTER CHOICE"
 	},
 	{
-		"altTitles": [
-			"Oshama Scramble!"
-		],
+		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
 			"artistJP": "t+pazolite",
@@ -3276,9 +3062,7 @@
 		"title": "Oshama Scramble!"
 	},
 	{
-		"altTitles": [
-			"D✪N’T  ST✪P  R✪CKIN’"
-		],
+		"altTitles": [],
 		"artist": "EB(aka EarBreaker)",
 		"data": {
 			"artistJP": "EB(aka EarBreaker)",
@@ -3304,9 +3088,7 @@
 		"title": "Helix of Garatia"
 	},
 	{
-		"altTitles": [
-			"oboro"
-		],
+		"altTitles": [],
 		"artist": "Hige Driver",
 		"data": {
 			"artistJP": "ヒゲドライバー",
@@ -3318,9 +3100,7 @@
 		"title": "oboro"
 	},
 	{
-		"altTitles": [
-			"Dragoon"
-		],
+		"altTitles": [],
 		"artist": "Shandy kubota",
 		"data": {
 			"artistJP": "Shandy kubota",
@@ -3332,9 +3112,7 @@
 		"title": "Dragoon"
 	},
 	{
-		"altTitles": [
-			"Stand Up!!!!"
-		],
+		"altTitles": [],
 		"artist": "Yua Suzuki(CV:Asuka Nishi)/Hina Sato(CV:Satomi Akesaka)/Aoi Takahashi(CV:Karin Ogino)/Koharu Tanaka(CV:Ayaka Ohashi)/“Tesagure!bukatsumono”",
 		"data": {
 			"artistJP": "鈴木結愛(CV:西 明日香)/佐藤陽菜(CV:明坂聡美)/高橋 葵(CV:荻野可鈴)/田中心春(CV:大橋彩香)/「てさぐれ！部活もの」 [アニメPV]",
@@ -3360,9 +3138,7 @@
 		"title": "Unhappy Refrain"
 	},
 	{
-		"altTitles": [
-			"One Step Ahead"
-		],
+		"altTitles": [],
 		"artist": "Kashitaro Ito",
 		"data": {
 			"artistJP": "伊東歌詞太郎",
@@ -3374,9 +3150,7 @@
 		"title": "One Step Ahead"
 	},
 	{
-		"altTitles": [
-			"L9"
-		],
+		"altTitles": [],
 		"artist": "paraoka",
 		"data": {
 			"artistJP": "paraoka",
@@ -3388,9 +3162,7 @@
 		"title": "L9"
 	},
 	{
-		"altTitles": [
-			"planet dancer"
-		],
+		"altTitles": [],
 		"artist": "Eiichiro Taruki",
 		"data": {
 			"artistJP": "樽木栄一郎",
@@ -3402,9 +3174,7 @@
 		"title": "planet dancer"
 	},
 	{
-		"altTitles": [
-			"Caliburne ～Story of the Legendary sword～"
-		],
+		"altTitles": [],
 		"artist": "Project Grimoire",
 		"data": {
 			"artistJP": "Project Grimoire",
@@ -3430,9 +3200,7 @@
 		"title": "Doushite Kou Natta"
 	},
 	{
-		"altTitles": [
-			"B.B.K.K.B.K.K."
-		],
+		"altTitles": [],
 		"artist": "nora2r",
 		"data": {
 			"artistJP": "nora2r",
@@ -3458,9 +3226,7 @@
 		"title": "Okocyama Sensou"
 	},
 	{
-		"altTitles": [
-			"Link"
-		],
+		"altTitles": [],
 		"artist": "Circle of friends(天月-あまつき-・un:c・伊東歌詞太郎・コニー・はしやん)",
 		"data": {
 			"artistJP": "Circle of friends(天月-あまつき-・un:c・伊東歌詞太郎・コニー・はしやん)",
@@ -3472,9 +3238,7 @@
 		"title": "Link"
 	},
 	{
-		"altTitles": [
-			"VERTeX"
-		],
+		"altTitles": [],
 		"artist": "Hiro「maimai」より",
 		"data": {
 			"artistJP": "Hiro「maimai」より",
@@ -3486,9 +3250,7 @@
 		"title": "VERTeX"
 	},
 	{
-		"altTitles": [
-			"Ignis Danse"
-		],
+		"altTitles": [],
 		"artist": "Yuji Masubuchi「太鼓の達人」より",
 		"data": {
 			"artistJP": "Yuji Masubuchi「太鼓の達人」より",
@@ -3500,9 +3262,7 @@
 		"title": "Ignis Danse"
 	},
 	{
-		"altTitles": [
-			"Scars of FAUNA"
-		],
+		"altTitles": [],
 		"artist": "猫叉Master「jubeat」より",
 		"data": {
 			"artistJP": "猫叉Master「jubeat」より",
@@ -3514,9 +3274,7 @@
 		"title": "Scars of FAUNA"
 	},
 	{
-		"altTitles": [
-			"FUJIN Rumble"
-		],
+		"altTitles": [],
 		"artist": "COSIO(ZUNTATA)「グルーヴコースター」より",
 		"data": {
 			"artistJP": "COSIO(ZUNTATA)「グルーヴコースター」より",
@@ -3528,9 +3286,7 @@
 		"title": "FUJIN Rumble"
 	},
 	{
-		"altTitles": [
-			"きたさいたま2000"
-		],
+		"altTitles": [],
 		"artist": "LindaAI-CUE(BNGI)「太鼓の達人」より",
 		"data": {
 			"artistJP": "LindaAI-CUE(BNGI)「太鼓の達人」より",
@@ -3542,9 +3298,7 @@
 		"title": "きたさいたま2000"
 	},
 	{
-		"altTitles": [
-			"FLOWER"
-		],
+		"altTitles": [],
 		"artist": "DJ YOSHITAKA「jubeat」より",
 		"data": {
 			"artistJP": "DJ YOSHITAKA「jubeat」より",
@@ -3556,9 +3310,7 @@
 		"title": "FLOWER"
 	},
 	{
-		"altTitles": [
-			"Got more raves？"
-		],
+		"altTitles": [],
 		"artist": "E.G.G.「グルーヴコースター」より",
 		"data": {
 			"artistJP": "E.G.G.「グルーヴコースター」より",
@@ -3640,9 +3392,7 @@
 		"title": "Kyouen"
 	},
 	{
-		"altTitles": [
-			"LOL -lots of laugh-"
-		],
+		"altTitles": [],
 		"artist": "KeN/Endcape",
 		"data": {
 			"artistJP": "KeN/エンドケイプ",
@@ -3794,9 +3544,7 @@
 		"title": "Streaming Heart"
 	},
 	{
-		"altTitles": [
-			"Change Our MIRAI！"
-		],
+		"altTitles": [],
 		"artist": "IRODORIMIDORI",
 		"data": {
 			"artistJP": "イロドリミドリ「CHUNITHM」",
@@ -3808,9 +3556,7 @@
 		"title": "Change Our MIRAI！"
 	},
 	{
-		"altTitles": [
-			"Aiolos"
-		],
+		"altTitles": [],
 		"artist": "xi",
 		"data": {
 			"artistJP": "xi",
@@ -3822,9 +3568,7 @@
 		"title": "Aiolos"
 	},
 	{
-		"altTitles": [
-			"LANCE"
-		],
+		"altTitles": [],
 		"artist": "Ras",
 		"data": {
 			"artistJP": "Ras",
@@ -3836,9 +3580,7 @@
 		"title": "LANCE"
 	},
 	{
-		"altTitles": [
-			"SAVIOR OF SONG"
-		],
+		"altTitles": [],
 		"artist": "nano feat.MY FIRST STORY",
 		"data": {
 			"artistJP": "ナノ feat.MY FIRST STORY",
@@ -3906,9 +3648,7 @@
 		"title": "Maiden's Illusionary Funeral Elegy - Necro Fantasia"
 	},
 	{
-		"altTitles": [
-			"Contrapasso -paradiso-"
-		],
+		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
 			"artistJP": "t+pazolite",
@@ -4032,9 +3772,7 @@
 		"title": "Nice To Meet You Mr. Earthling"
 	},
 	{
-		"altTitles": [
-			"Pursuing My True Self "
-		],
+		"altTitles": [],
 		"artist": "目黒 将司",
 		"data": {
 			"artistJP": "目黒 将司",
@@ -4046,9 +3784,7 @@
 		"title": "Pursuing My True Self "
 	},
 	{
-		"altTitles": [
-			"Signs Of Love (“Never More” ver.)"
-		],
+		"altTitles": [],
 		"artist": "目黒 将司",
 		"data": {
 			"artistJP": "目黒 将司",
@@ -4060,9 +3796,7 @@
 		"title": "Signs Of Love (“Never More” ver.)"
 	},
 	{
-		"altTitles": [
-			"specialist (“Never More” ver.)"
-		],
+		"altTitles": [],
 		"artist": "目黒 将司",
 		"data": {
 			"artistJP": "目黒 将司",
@@ -4074,9 +3808,7 @@
 		"title": "specialist (“Never More” ver.)"
 	},
 	{
-		"altTitles": [
-			"Time To Make History (AKIRA YAMAOKA Remix)"
-		],
+		"altTitles": [],
 		"artist": "目黒 将司 Remixed by 山岡 晃",
 		"data": {
 			"artistJP": "目黒 将司 Remixed by 山岡 晃",
@@ -4088,9 +3820,7 @@
 		"title": "Time To Make History (AKIRA YAMAOKA Remix)"
 	},
 	{
-		"altTitles": [
-			"GEMINI -M-"
-		],
+		"altTitles": [],
 		"artist": "Tatsh",
 		"data": {
 			"artistJP": "Tatsh",
@@ -4102,9 +3832,7 @@
 		"title": "GEMINI -M-"
 	},
 	{
-		"altTitles": [
-			"+♂"
-		],
+		"altTitles": [],
 		"artist": "Giga/Reol dance ARSMAGNA",
 		"data": {
 			"artistJP": "ギガ/れをる　ダンス　アルスマグナ",
@@ -4172,9 +3900,7 @@
 		"title": "Tonchinkan no en"
 	},
 	{
-		"altTitles": [
-			"Garden Of The Dragon"
-		],
+		"altTitles": [],
 		"artist": "Kai「Wonderland Wars」",
 		"data": {
 			"artistJP": "Kai「Wonderland Wars」",
@@ -4186,9 +3912,7 @@
 		"title": "Garden Of The Dragon"
 	},
 	{
-		"altTitles": [
-			"After Burner"
-		],
+		"altTitles": [],
 		"artist": "Tokyo Active NEETs",
 		"data": {
 			"artistJP": "東京アクティブNEETs",
@@ -4200,9 +3924,7 @@
 		"title": "After Burner"
 	},
 	{
-		"altTitles": [
-			"Counselor"
-		],
+		"altTitles": [],
 		"artist": "DECO*27 feat.echo",
 		"data": {
 			"artistJP": "DECO*27 feat.echo",
@@ -4214,9 +3936,7 @@
 		"title": "Counselor"
 	},
 	{
-		"altTitles": [
-			"Glorious Crown"
-		],
+		"altTitles": [],
 		"artist": "xi",
 		"data": {
 			"artistJP": "xi",
@@ -4298,9 +4018,7 @@
 		"title": "MUTEKI We are one!!"
 	},
 	{
-		"altTitles": [
-			"7thSense"
-		],
+		"altTitles": [],
 		"artist": "Sakuzyo",
 		"data": {
 			"artistJP": "削除",
@@ -4312,9 +4030,7 @@
 		"title": "7thSense"
 	},
 	{
-		"altTitles": [
-			"FEEL the BEATS"
-		],
+		"altTitles": [],
 		"artist": "A-One",
 		"data": {
 			"artistJP": "A-One",
@@ -4326,9 +4042,7 @@
 		"title": "FEEL the BEATS"
 	},
 	{
-		"altTitles": [
-			"Revive The Rave"
-		],
+		"altTitles": [],
 		"artist": "void(Mournfinale)",
 		"data": {
 			"artistJP": "void(Mournfinale)",
@@ -4354,9 +4068,7 @@
 		"title": "Slip Flip"
 	},
 	{
-		"altTitles": [
-			"Jimang Shot"
-		],
+		"altTitles": [],
 		"artist": "JIMANG",
 		"data": {
 			"artistJP": "じまんぐ",
@@ -4480,9 +4192,7 @@
 		"title": "HIMITSU SPARK"
 	},
 	{
-		"altTitles": [
-			"Party 4U ”holy nite mix”"
-		],
+		"altTitles": [],
 		"artist": "Cranky",
 		"data": {
 			"artistJP": "Cranky",
@@ -4508,9 +4218,7 @@
 		"title": "kakoinakiyohaichigonotsukikage"
 	},
 	{
-		"altTitles": [
-			"Lividi"
-		],
+		"altTitles": [],
 		"artist": "Feryquitous",
 		"data": {
 			"artistJP": "Feryquitous",
@@ -4522,9 +4230,7 @@
 		"title": "Lividi"
 	},
 	{
-		"altTitles": [
-			"Infantoon Fantasy"
-		],
+		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
 			"artistJP": "t+pazolite",
@@ -4536,9 +4242,7 @@
 		"title": "Infantoon Fantasy"
 	},
 	{
-		"altTitles": [
-			"Jumble Rumble"
-		],
+		"altTitles": [],
 		"artist": "INNOCENT NOIZE",
 		"data": {
 			"artistJP": "INNOCENT NOIZE",
@@ -4550,9 +4254,7 @@
 		"title": "Jumble Rumble"
 	},
 	{
-		"altTitles": [
-			"Imitation:Loud Lounge"
-		],
+		"altTitles": [],
 		"artist": "Ino(chronoize)",
 		"data": {
 			"artistJP": "Ino(chronoize)",
@@ -4564,9 +4266,7 @@
 		"title": "Imitation:Loud Lounge"
 	},
 	{
-		"altTitles": [
-			"CITRUS MONSTER"
-		],
+		"altTitles": [],
 		"artist": "D-Cee",
 		"data": {
 			"artistJP": "D-Cee",
@@ -4578,9 +4278,7 @@
 		"title": "CITRUS MONSTER"
 	},
 	{
-		"altTitles": [
-			"Hyper Active"
-		],
+		"altTitles": [],
 		"artist": "HiTECH NINJA",
 		"data": {
 			"artistJP": "HiTECH NINJA",
@@ -4592,9 +4290,7 @@
 		"title": "Hyper Active"
 	},
 	{
-		"altTitles": [
-			"AMAZING MIGHTYYYY!!!!"
-		],
+		"altTitles": [],
 		"artist": "WAiKURO",
 		"data": {
 			"artistJP": "WAiKURO",
@@ -4606,9 +4302,7 @@
 		"title": "AMAZING MIGHTYYYY!!!!"
 	},
 	{
-		"altTitles": [
-			"fake!fake!"
-		],
+		"altTitles": [],
 		"artist": "A crow is white",
 		"data": {
 			"artistJP": "カラスは真っ白",
@@ -4648,9 +4342,7 @@
 		"title": "Sugar Song and Bitter Step"
 	},
 	{
-		"altTitles": [
-			"Daydream café"
-		],
+		"altTitles": [],
 		"artist": "Petit Rabbit's“Is the order a rabbit?”",
 		"data": {
 			"artistJP": "Petit Rabbit's「ご注文はうさぎですか？」",
@@ -4662,9 +4354,7 @@
 		"title": "Daydream café"
 	},
 	{
-		"altTitles": [
-			"ちょちょちょ！ゆるゆり☆かぷりっちょ！！！"
-		],
+		"altTitles": [],
 		"artist": "七森中☆ごらく部「ゆるゆり さん☆ハイ！」",
 		"data": {
 			"artistJP": "七森中☆ごらく部「ゆるゆり さん☆ハイ！」",
@@ -4718,9 +4408,7 @@
 		"title": "Love Trial"
 	},
 	{
-		"altTitles": [
-			"Just Be Friends"
-		],
+		"altTitles": [],
 		"artist": "Dixie Flatline",
 		"data": {
 			"artistJP": "Dixie Flatline",
@@ -4760,9 +4448,7 @@
 		"title": "Perfect Life"
 	},
 	{
-		"altTitles": [
-			"StargazeR"
-		],
+		"altTitles": [],
 		"artist": "KotsuBeirneP",
 		"data": {
 			"artistJP": "骨盤P",
@@ -4886,9 +4572,7 @@
 		"title": "Kiborinamazu to Migikatazonbi"
 	},
 	{
-		"altTitles": [
-			"ECHO"
-		],
+		"altTitles": [],
 		"artist": "CIRCRUSH",
 		"data": {
 			"artistJP": "CIRCRUSH",
@@ -4900,9 +4584,7 @@
 		"title": "ECHO"
 	},
 	{
-		"altTitles": [
-			"Mr. Wonderland"
-		],
+		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
 			"artistJP": "sasakure.UK",
@@ -4928,9 +4610,7 @@
 		"title": "SHINDESHIMAUTOWA NASAKENAI"
 	},
 	{
-		"altTitles": [
-			"Hand in Hand"
-		],
+		"altTitles": [],
 		"artist": "livetune",
 		"data": {
 			"artistJP": "livetune",
@@ -4956,9 +4636,7 @@
 		"title": "BURIKI NO DANCE"
 	},
 	{
-		"altTitles": [
-			"brilliant better"
-		],
+		"altTitles": [],
 		"artist": "Aliciana Ogata(CV:Ayaka Fukuhara)",
 		"data": {
 			"artistJP": "御形 アリシアナ(CV:福原 綾香)",
@@ -4984,9 +4662,7 @@
 		"title": "heart・beat"
 	},
 	{
-		"altTitles": [
-			"Invitation"
-		],
+		"altTitles": [],
 		"artist": "rerulili feat.Lon",
 		"data": {
 			"artistJP": "れるりり feat.ろん",
@@ -4998,9 +4674,7 @@
 		"title": "Invitation"
 	},
 	{
-		"altTitles": [
-			"connecting with you"
-		],
+		"altTitles": [],
 		"artist": "Takahiro Eguchi feat. Aki Misawa",
 		"data": {
 			"artistJP": "Takahiro Eguchi feat. 三澤秋",
@@ -5026,9 +4700,7 @@
 		"title": "Anticyclone Cat Rock"
 	},
 	{
-		"altTitles": [
-			"Prophesy One"
-		],
+		"altTitles": [],
 		"artist": "vox2 (Hideyuki Ono)",
 		"data": {
 			"artistJP": "vox2（小野秀幸）",
@@ -5054,9 +4726,7 @@
 		"title": "Sennou"
 	},
 	{
-		"altTitles": [
-			"Barbed Eye"
-		],
+		"altTitles": [],
 		"artist": "Kakichoco×MikitoP",
 		"data": {
 			"artistJP": "柿チョコ×みきとP",
@@ -5068,9 +4738,7 @@
 		"title": "Barbed Eye"
 	},
 	{
-		"altTitles": [
-			"Nitrous Fury"
-		],
+		"altTitles": [],
 		"artist": "Jun Senoue",
 		"data": {
 			"artistJP": "Jun Senoue",
@@ -5110,9 +4778,7 @@
 		"title": "Tsuki Ni Murakumo Hana Ni Kaze"
 	},
 	{
-		"altTitles": [
-			"No Routine"
-		],
+		"altTitles": [],
 		"artist": "A-One",
 		"data": {
 			"artistJP": "A-One",
@@ -5180,9 +4846,7 @@
 		"title": "Kachoufugetsu"
 	},
 	{
-		"altTitles": [
-			"METATRON"
-		],
+		"altTitles": [],
 		"artist": "SHIKI",
 		"data": {
 			"artistJP": "SHIKI",
@@ -5208,9 +4872,7 @@
 		"title": "OWARINAKIMONOGATARI"
 	},
 	{
-		"altTitles": [
-			"ゆりゆららららゆるゆり大事件"
-		],
+		"altTitles": [],
 		"artist": "七森中☆ごらく部「ゆるゆり」",
 		"data": {
 			"artistJP": "七森中☆ごらく部「ゆるゆり」",
@@ -5236,9 +4898,7 @@
 		"title": "Fortissimo BELL"
 	},
 	{
-		"altTitles": [
-			"私の中の幻想的世界観及びその顕現を想起させたある現実での出来事に関する一考察"
-		],
+		"altTitles": [],
 		"artist": "Nagi Kobotoke(CV:Kaoru Sakura)",
 		"data": {
 			"artistJP": "小仏 凪(CV:佐倉 薫)",
@@ -5250,9 +4910,7 @@
 		"title": "私の中の幻想的世界観及びその顕現を想起させたある現実での出来事に関する一考察"
 	},
 	{
-		"altTitles": [
-			"DETARAME ROCK&ROLL THEORY"
-		],
+		"altTitles": [],
 		"artist": "Naru Hakobe(CV:M・A・O)",
 		"data": {
 			"artistJP": "箱部 なる(CV:M・A・O)",
@@ -5264,9 +4922,7 @@
 		"title": "DETARAME ROCK&ROLL THEORY"
 	},
 	{
-		"altTitles": [
-			"PERFECT HUMAN"
-		],
+		"altTitles": [],
 		"artist": "RADIO FISH",
 		"data": {
 			"artistJP": "RADIO FISH",
@@ -5320,9 +4976,7 @@
 		"title": "Chururira・Chururira・Daddadda!"
 	},
 	{
-		"altTitles": [
-			"GOODMEN"
-		],
+		"altTitles": [],
 		"artist": "EBIMAYO",
 		"data": {
 			"artistJP": "EBIMAYO",
@@ -5334,9 +4988,7 @@
 		"title": "GOODMEN"
 	},
 	{
-		"altTitles": [
-			"夜明けまであと３秒"
-		],
+		"altTitles": [],
 		"artist": "BNSI（Taku Inoue）「シンクロニカ」より",
 		"data": {
 			"artistJP": "BNSI（Taku Inoue）「シンクロニカ」より",
@@ -5348,9 +5000,7 @@
 		"title": "夜明けまであと３秒"
 	},
 	{
-		"altTitles": [
-			"Last Brave ～ Go to zero"
-		],
+		"altTitles": [],
 		"artist": "MECHANiCAL PANDA“BORDER BREAK”",
 		"data": {
 			"artistJP": "MECHANiCAL PANDA「BORDER BREAK」",
@@ -5362,9 +5012,7 @@
 		"title": "Last Brave ～ Go to zero"
 	},
 	{
-		"altTitles": [
-			"STAIRWAY TO GENERATION"
-		],
+		"altTitles": [],
 		"artist": "Yosh(Survive Said The Prophet)",
 		"data": {
 			"artistJP": "Yosh(Survive Said The Prophet)",
@@ -5390,9 +5038,7 @@
 		"title": "brash behavior"
 	},
 	{
-		"altTitles": [
-			"回レ！雪月花"
-		],
+		"altTitles": [],
 		"artist": "歌組雪月花 夜々(原田ひとみ)/いろり(茅野愛衣)/小紫(小倉唯)「機巧少女は傷つかない」",
 		"data": {
 			"artistJP": "歌組雪月花 夜々(原田ひとみ)/いろり(茅野愛衣)/小紫(小倉唯)「機巧少女は傷つかない」",
@@ -5418,9 +5064,7 @@
 		"title": "How to be maimai sinken master!"
 	},
 	{
-		"altTitles": [
-			"いぇす！ゆゆゆ☆ゆるゆり♪♪"
-		],
+		"altTitles": [],
 		"artist": "七森中☆ごらく部「ゆるゆり♪♪」",
 		"data": {
 			"artistJP": "七森中☆ごらく部「ゆるゆり♪♪」",
@@ -5432,9 +5076,7 @@
 		"title": "いぇす！ゆゆゆ☆ゆるゆり♪♪"
 	},
 	{
-		"altTitles": [
-			"ENJOY POLIS"
-		],
+		"altTitles": [],
 		"artist": "LOPIT",
 		"data": {
 			"artistJP": "LOPIT",
@@ -5474,9 +5116,7 @@
 		"title": "Amenohoakari"
 	},
 	{
-		"altTitles": [
-			"HERA"
-		],
+		"altTitles": [],
 		"artist": "LUZE",
 		"data": {
 			"artistJP": "ルゼ",
@@ -5502,9 +5142,7 @@
 		"title": "Wakaranai"
 	},
 	{
-		"altTitles": [
-			"Our Wrenally"
-		],
+		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
 			"artistJP": "t+pazolite",
@@ -5516,9 +5154,7 @@
 		"title": "Our Wrenally"
 	},
 	{
-		"altTitles": [
-			"Scream out! -maimai SONIC WASHER Edit-"
-		],
+		"altTitles": [],
 		"artist": "A-One",
 		"data": {
 			"artistJP": "A-One",
@@ -5544,9 +5180,7 @@
 		"title": "April showers"
 	},
 	{
-		"altTitles": [
-			"Selector"
-		],
+		"altTitles": [],
 		"artist": "Aliesrite* (Ym1024 feat. lamie*)",
 		"data": {
 			"artistJP": "Aliesrite* (Ym1024 feat. lamie*)",
@@ -5558,9 +5192,7 @@
 		"title": "Selector"
 	},
 	{
-		"altTitles": [
-			"Star☆Glitter"
-		],
+		"altTitles": [],
 		"artist": "7TH SISTERS",
 		"data": {
 			"artistJP": "セブンスシスターズ",
@@ -5572,9 +5204,7 @@
 		"title": "Star☆Glitter"
 	},
 	{
-		"altTitles": [
-			"H-A-J-I-M-A-R-I-U-T-A-!!"
-		],
+		"altTitles": [],
 		"artist": "777☆SISTERS",
 		"data": {
 			"artistJP": "777☆SISTERS",
@@ -5656,9 +5286,7 @@
 		"title": "Anything which was awakened to phantom-dusk"
 	},
 	{
-		"altTitles": [
-			"Starlight Vision"
-		],
+		"altTitles": [],
 		"artist": "Tsukasa feat. Aki Misawa",
 		"data": {
 			"artistJP": "矢鴇つかさ feat. 三澤秋",
@@ -5670,9 +5298,7 @@
 		"title": "Starlight Vision"
 	},
 	{
-		"altTitles": [
-			"Club Ibuki in Break All"
-		],
+		"altTitles": [],
 		"artist": "void + YoshimiYOUNO feat. MarinaFujiwara",
 		"data": {
 			"artistJP": "void＋夕野ヨシミ (IOSYS) feat.藤原鞠菜",
@@ -5684,9 +5310,7 @@
 		"title": "Club Ibuki in Break All"
 	},
 	{
-		"altTitles": [
-			"Phantasm Brigade"
-		],
+		"altTitles": [],
 		"artist": "Silver Forest",
 		"data": {
 			"artistJP": "Silver Forest",
@@ -5726,9 +5350,7 @@
 		"title": "Shirayuki"
 	},
 	{
-		"altTitles": [
-			"Panopticon"
-		],
+		"altTitles": [],
 		"artist": "cybermiso",
 		"data": {
 			"artistJP": "cybermiso",
@@ -5740,9 +5362,7 @@
 		"title": "Panopticon"
 	},
 	{
-		"altTitles": [
-			"Sakura Fubuki"
-		],
+		"altTitles": [],
 		"artist": "Street",
 		"data": {
 			"artistJP": "Street",
@@ -5754,9 +5374,7 @@
 		"title": "Sakura Fubuki"
 	},
 	{
-		"altTitles": [
-			"conflict"
-		],
+		"altTitles": [],
 		"artist": "siromaru + cranky",
 		"data": {
 			"artistJP": "siromaru + cranky",
@@ -5824,9 +5442,7 @@
 		"title": "Kirasse! Wood Village Farm"
 	},
 	{
-		"altTitles": [
-			"taboo tears you up"
-		],
+		"altTitles": [],
 		"artist": "REDALiCE (HARDCORE TANO*C)",
 		"data": {
 			"artistJP": "REDALiCE (HARDCORE TANO*C)",
@@ -5838,9 +5454,7 @@
 		"title": "taboo tears you up"
 	},
 	{
-		"altTitles": [
-			"その群青が愛しかったようだった"
-		],
+		"altTitles": [],
 		"artist": "n-buna feat. KANA YAGINUMA",
 		"data": {
 			"artistJP": "n-buna feat.ヤギヌマカナ",
@@ -5852,9 +5466,7 @@
 		"title": "その群青が愛しかったようだった"
 	},
 	{
-		"altTitles": [
-			"Jumping!!"
-		],
+		"altTitles": [],
 		"artist": "Rhodanthe*",
 		"data": {
 			"artistJP": "Rhodanthe*",
@@ -5866,9 +5478,7 @@
 		"title": "Jumping!!"
 	},
 	{
-		"altTitles": [
-			"7 Girls War"
-		],
+		"altTitles": [],
 		"artist": "Wake Up, Girls！",
 		"data": {
 			"artistJP": "Wake Up, Girls！",
@@ -5880,9 +5490,7 @@
 		"title": "7 Girls War"
 	},
 	{
-		"altTitles": [
-			"The wheel to the right"
-		],
+		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
 			"artistJP": "Sampling Masters MEGA",
@@ -5908,9 +5516,7 @@
 		"title": "Zenzenzense"
 	},
 	{
-		"altTitles": [
-			"SAKURAスキップ"
-		],
+		"altTitles": [],
 		"artist": "fourfolium「NEW GAME!」",
 		"data": {
 			"artistJP": "fourfolium「NEW GAME!」",
@@ -5950,9 +5556,7 @@
 		"title": "Syukudai ga owaranai!"
 	},
 	{
-		"altTitles": [
-			"GO BACK 2 YOUR RAVE"
-		],
+		"altTitles": [],
 		"artist": "nora2r",
 		"data": {
 			"artistJP": "nora2r",
@@ -5992,9 +5596,7 @@
 		"title": "YumeHANABI"
 	},
 	{
-		"altTitles": [
-			"Paradisus-Paradoxum"
-		],
+		"altTitles": [],
 		"artist": "MYTH & ROID「Re：ゼロから始める異世界生活」",
 		"data": {
 			"artistJP": "MYTH & ROID「Re：ゼロから始める異世界生活」",
@@ -6048,9 +5650,7 @@
 		"title": "Tokyo Retro"
 	},
 	{
-		"altTitles": [
-			"ARROW"
-		],
+		"altTitles": [],
 		"artist": "niki",
 		"data": {
 			"artistJP": "niki",
@@ -6076,9 +5676,7 @@
 		"title": "BAD・DANCE・HALL"
 	},
 	{
-		"altTitles": [
-			"KISS CANDY FLAVOR"
-		],
+		"altTitles": [],
 		"artist": "Colorful Sounds Port",
 		"data": {
 			"artistJP": "カラフル・サウンズ・ポート",
@@ -6090,9 +5688,7 @@
 		"title": "KISS CANDY FLAVOR"
 	},
 	{
-		"altTitles": [
-			"Maxi"
-		],
+		"altTitles": [],
 		"artist": "Nizikawa",
 		"data": {
 			"artistJP": "Nizikawa",
@@ -6146,9 +5742,7 @@
 		"title": "Ray Tuning"
 	},
 	{
-		"altTitles": [
-			"Limit Break"
-		],
+		"altTitles": [],
 		"artist": "DiGiTAL WiNG",
 		"data": {
 			"artistJP": "DiGiTAL WiNG",
@@ -6174,9 +5768,7 @@
 		"title": "Aimai Mind"
 	},
 	{
-		"altTitles": [
-			"KING is BACK!!"
-		],
+		"altTitles": [],
 		"artist": "A-One",
 		"data": {
 			"artistJP": "A-One",
@@ -6188,9 +5780,7 @@
 		"title": "KING is BACK!!"
 	},
 	{
-		"altTitles": [
-			"Ultranova"
-		],
+		"altTitles": [],
 		"artist": "A4paper",
 		"data": {
 			"artistJP": "A4paper",
@@ -6244,9 +5834,7 @@
 		"title": "NAISEN NO UTA"
 	},
 	{
-		"altTitles": [
-			"Starlight Dance Floor"
-		],
+		"altTitles": [],
 		"artist": "Hatsunetsumiko's",
 		"data": {
 			"artistJP": "発熱巫女〜ず",
@@ -6272,9 +5860,7 @@
 		"title": "Lunate Elf - Birthday Festival of the Moon"
 	},
 	{
-		"altTitles": [
-			"Calamity Fortune"
-		],
+		"altTitles": [],
 		"artist": "LeaF",
 		"data": {
 			"artistJP": "LeaF",
@@ -6286,9 +5872,7 @@
 		"title": "Calamity Fortune"
 	},
 	{
-		"altTitles": [
-			"Justified"
-		],
+		"altTitles": [],
 		"artist": "MintJam feat.Takenobu Mitsuyoshi",
 		"data": {
 			"artistJP": "MintJam feat.光吉猛修",
@@ -6300,9 +5884,7 @@
 		"title": "Justified"
 	},
 	{
-		"altTitles": [
-			"Excalibur ～Revived resolution～"
-		],
+		"altTitles": [],
 		"artist": "Project Grimoire",
 		"data": {
 			"artistJP": "Project Grimoire",
@@ -6314,9 +5896,7 @@
 		"title": "Excalibur ～Revived resolution～"
 	},
 	{
-		"altTitles": [
-			"ホシトハナ"
-		],
+		"altTitles": [],
 		"artist": "讃州中学勇者部「結城友奈は勇者である」",
 		"data": {
 			"artistJP": "讃州中学勇者部「結城友奈は勇者である」",
@@ -6356,9 +5936,7 @@
 		"title": "Alien Alien"
 	},
 	{
-		"altTitles": [
-			"My Dearest Song"
-		],
+		"altTitles": [],
 		"artist": "Shirona Tsukisuzu(CV:Marika Kouno)",
 		"data": {
 			"artistJP": "月鈴 白奈(CV:高野 麻里佳)",
@@ -6384,9 +5962,7 @@
 		"title": "Mo-shin Soliste Life!"
 	},
 	{
-		"altTitles": [
-			"Let's Go Away"
-		],
+		"altTitles": [],
 		"artist": "Takenobu Mitsuyoshi“Daytona Championship USA”",
 		"data": {
 			"artistJP": "光吉猛修「デイトナ Championship USA」",
@@ -6398,9 +5974,7 @@
 		"title": "Let's Go Away"
 	},
 	{
-		"altTitles": [
-			"Now Loading!!!!"
-		],
+		"altTitles": [],
 		"artist": "fourfolium「NEW GAME!」",
 		"data": {
 			"artistJP": "fourfolium「NEW GAME!」",
@@ -6482,9 +6056,7 @@
 		"title": "girigiri saikyou Ai Mai Mi!"
 	},
 	{
-		"altTitles": [
-			"CALL HEAVEN!!"
-		],
+		"altTitles": [],
 		"artist": "YUMEIRO CAST",
 		"data": {
 			"artistJP": "夢色キャスト",
@@ -6496,9 +6068,7 @@
 		"title": "CALL HEAVEN!!"
 	},
 	{
-		"altTitles": [
-			"Sunshine world tour"
-		],
+		"altTitles": [],
 		"artist": "YUMEIRO CAST",
 		"data": {
 			"artistJP": "夢色キャスト",
@@ -6524,9 +6094,7 @@
 		"title": "CHIGAU!!!"
 	},
 	{
-		"altTitles": [
-			"Moon of Noon"
-		],
+		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
 			"artistJP": "Sampling Masters MEGA",
@@ -6608,9 +6176,7 @@
 		"title": "DONUT HOLE"
 	},
 	{
-		"altTitles": [
-			"MilK"
-		],
+		"altTitles": [],
 		"artist": "Morimori Atsushi",
 		"data": {
 			"artistJP": "モリモリあつし",
@@ -6636,9 +6202,7 @@
 		"title": "Sakihokore Tokoyo No Hana"
 	},
 	{
-		"altTitles": [
-			"Magical Flavor"
-		],
+		"altTitles": [],
 		"artist": "DECO*27 feat.Tia",
 		"data": {
 			"artistJP": "DECO*27 feat.Tia",
@@ -6692,9 +6256,7 @@
 		"title": "Star Night Snow"
 	},
 	{
-		"altTitles": [
-			"This game"
-		],
+		"altTitles": [],
 		"artist": "Konomi suzuki“No Game,No Life”",
 		"data": {
 			"artistJP": "鈴木このみ「ノーゲーム・ノーライフ」",
@@ -6706,9 +6268,7 @@
 		"title": "This game"
 	},
 	{
-		"altTitles": [
-			"Los! Los! Los!"
-		],
+		"altTitles": [],
 		"artist": "Tanya Degurechaff(CV:Aoi Yūki)“Saga of Tanya the Evil”",
 		"data": {
 			"artistJP": "ターニャ・デグレチャフ(CV.悠木碧)「幼女戦記」",
@@ -6720,9 +6280,7 @@
 		"title": "Los! Los! Los!"
 	},
 	{
-		"altTitles": [
-			"Candy Tall Woman"
-		],
+		"altTitles": [],
 		"artist": "naotyu- feat. Eri Sasaki",
 		"data": {
 			"artistJP": "naotyu- feat. 佐々木恵梨",
@@ -6734,9 +6292,7 @@
 		"title": "Candy Tall Woman"
 	},
 	{
-		"altTitles": [
-			"Signature"
-		],
+		"altTitles": [],
 		"artist": "Palme",
 		"data": {
 			"artistJP": "Palme",
@@ -6818,9 +6374,7 @@
 		"title": "Kirin"
 	},
 	{
-		"altTitles": [
-			"Credits"
-		],
+		"altTitles": [],
 		"artist": "Frums",
 		"data": {
 			"artistJP": "Frums",
@@ -6902,9 +6456,7 @@
 		"title": "Neko Matsuri"
 	},
 	{
-		"altTitles": [
-			"TRUST"
-		],
+		"altTitles": [],
 		"artist": "Nagi Kobotoke(CV:Kaoru Sakura)",
 		"data": {
 			"artistJP": "小仏 凪(CV:佐倉 薫)",
@@ -6916,9 +6468,7 @@
 		"title": "TRUST"
 	},
 	{
-		"altTitles": [
-			"Still"
-		],
+		"altTitles": [],
 		"artist": "IRODORIMIDORI",
 		"data": {
 			"artistJP": "イロドリミドリ「CHUNITHM」",
@@ -6944,9 +6494,7 @@
 		"title": "Gabriel DropKick"
 	},
 	{
-		"altTitles": [
-			"fantastic dreamer"
-		],
+		"altTitles": [],
 		"artist": "Machico“GOOD'S BLESSING ON THIS WONDERFUL WORLD!”",
 		"data": {
 			"artistJP": "Machico「この素晴らしい世界に祝福を！」",
@@ -6986,9 +6534,7 @@
 		"title": "Sissou Ensemble"
 	},
 	{
-		"altTitles": [
-			"Doll Judgment"
-		],
+		"altTitles": [],
 		"artist": "Nuruhachi",
 		"data": {
 			"artistJP": "ぬるはち",
@@ -7000,9 +6546,7 @@
 		"title": "Doll Judgment"
 	},
 	{
-		"altTitles": [
-			"WARNING×WARNING×WARNING"
-		],
+		"altTitles": [],
 		"artist": "akatsuki-records",
 		"data": {
 			"artistJP": "暁Records",
@@ -7014,9 +6558,7 @@
 		"title": "WARNING×WARNING×WARNING"
 	},
 	{
-		"altTitles": [
-			"SPILL OVER COLORS"
-		],
+		"altTitles": [],
 		"artist": "Tsukasa Yatoki feat. kalon.",
 		"data": {
 			"artistJP": "矢鴇つかさ feat. kalon.",
@@ -7028,9 +6570,7 @@
 		"title": "SPILL OVER COLORS"
 	},
 	{
-		"altTitles": [
-			"Mare Maris"
-		],
+		"altTitles": [],
 		"artist": "M2U",
 		"data": {
 			"artistJP": "M2U",
@@ -7140,9 +6680,7 @@
 		"title": "Miracle Shopping"
 	},
 	{
-		"altTitles": [
-			"Kinda Way"
-		],
+		"altTitles": [],
 		"artist": "good-cool ft. Pete Klassen",
 		"data": {
 			"artistJP": "good-cool ft. Pete Klassen",
@@ -7210,9 +6748,7 @@
 		"title": "Nonsense Literature"
 	},
 	{
-		"altTitles": [
-			"Bang Babang Bang!!!"
-		],
+		"altTitles": [],
 		"artist": "Aliciana Ogata(CV:Ayaka Fukuhara)",
 		"data": {
 			"artistJP": "御形 アリシアナ(CV:福原 綾香)",
@@ -7224,9 +6760,7 @@
 		"title": "Bang Babang Bang!!!"
 	},
 	{
-		"altTitles": [
-			"Tic Tac DREAMIN’"
-		],
+		"altTitles": [],
 		"artist": "Nazuna Tennozu(CV:Ayano Yamamoto)",
 		"data": {
 			"artistJP": "天王洲 なずな(CV:山本 彩乃)",
@@ -7238,9 +6772,7 @@
 		"title": "Tic Tac DREAMIN’"
 	},
 	{
-		"altTitles": [
-			"SPICY SWINGY STYLE"
-		],
+		"altTitles": [],
 		"artist": "Serina Akesaka(CV:Emi Nitta)",
 		"data": {
 			"artistJP": "明坂 芹菜(CV:新田 恵海)",
@@ -7280,9 +6812,7 @@
 		"title": "Unknown Mother-Goose"
 	},
 	{
-		"altTitles": [
-			"POP TEAM EPIC"
-		],
+		"altTitles": [],
 		"artist": "上坂すみれ「ポプテピピック」",
 		"data": {
 			"artistJP": "上坂すみれ「ポプテピピック」",
@@ -7294,9 +6824,7 @@
 		"title": "POP TEAM EPIC"
 	},
 	{
-		"altTitles": [
-			"にめんせい☆ウラオモテライフ！"
-		],
+		"altTitles": [],
 		"artist": "土間うまる（田中あいみ）「干物妹！うまるちゃんR」",
 		"data": {
 			"artistJP": "土間うまる（田中あいみ）「干物妹！うまるちゃんR」",
@@ -7308,9 +6836,7 @@
 		"title": "にめんせい☆ウラオモテライフ！"
 	},
 	{
-		"altTitles": [
-			"うまるん体操"
-		],
+		"altTitles": [],
 		"artist": "妹Ｓ「干物妹！うまるちゃんR」",
 		"data": {
 			"artistJP": "妹Ｓ「干物妹！うまるちゃんR」",
@@ -7336,9 +6862,7 @@
 		"title": "MKDR"
 	},
 	{
-		"altTitles": [
-			"LOVE EAST"
-		],
+		"altTitles": [],
 		"artist": "Akatsuki Records",
 		"data": {
 			"artistJP": "暁Records",
@@ -7350,9 +6874,7 @@
 		"title": "LOVE EAST"
 	},
 	{
-		"altTitles": [
-			"Fist Bump"
-		],
+		"altTitles": [],
 		"artist": "Tomoya Ohtani, Douglas Robb from Hoobastank “Sonic Forces”",
 		"data": {
 			"artistJP": "大谷智哉, Douglas Robb from Hoobastank「ソニック フォース」",
@@ -7364,9 +6886,7 @@
 		"title": "Fist Bump"
 	},
 	{
-		"altTitles": [
-			"ENERGY SYNERGY MATRIX"
-		],
+		"altTitles": [],
 		"artist": "Tanchiky",
 		"data": {
 			"artistJP": "Tanchiky",
@@ -7392,9 +6912,7 @@
 		"title": "Session High!!"
 	},
 	{
-		"altTitles": [
-			"World Vanquisher"
-		],
+		"altTitles": [],
 		"artist": "void (Mournfinale)",
 		"data": {
 			"artistJP": "void (Mournfinale)",
@@ -7406,9 +6924,7 @@
 		"title": "World Vanquisher"
 	},
 	{
-		"altTitles": [
-			"FestivaLight"
-		],
+		"altTitles": [],
 		"artist": "Haruka Shimotsuki",
 		"data": {
 			"artistJP": "霜月はるか",
@@ -7420,9 +6936,7 @@
 		"title": "FestivaLight"
 	},
 	{
-		"altTitles": [
-			"Brain Power"
-		],
+		"altTitles": [],
 		"artist": "NOMA",
 		"data": {
 			"artistJP": "ノマ",
@@ -7448,9 +6962,7 @@
 		"title": "Rebellion of the Dwarfs"
 	},
 	{
-		"altTitles": [
-			"ULTRA B+K"
-		],
+		"altTitles": [],
 		"artist": "nora2r",
 		"data": {
 			"artistJP": "nora2r",
@@ -7504,9 +7016,7 @@
 		"title": "Anti-clockwise"
 	},
 	{
-		"altTitles": [
-			"全力☆Summer!"
-		],
+		"altTitles": [],
 		"artist": "angela「アホガール」",
 		"data": {
 			"artistJP": "angela「アホガール」",
@@ -7518,9 +7028,7 @@
 		"title": "全力☆Summer!"
 	},
 	{
-		"altTitles": [
-			"keep hopping"
-		],
+		"altTitles": [],
 		"artist": "kamome sano",
 		"data": {
 			"artistJP": "kamome sano",
@@ -7532,9 +7040,7 @@
 		"title": "keep hopping"
 	},
 	{
-		"altTitles": [
-			"larva"
-		],
+		"altTitles": [],
 		"artist": "Garigari Samushi",
 		"data": {
 			"artistJP": "ガリガリさむし",
@@ -7574,9 +7080,7 @@
 		"title": "Miracle Paint"
 	},
 	{
-		"altTitles": [
-			"Ievan Polkka"
-		],
+		"altTitles": [],
 		"artist": "Otomania feat. Hatsune Miku",
 		"data": {
 			"artistJP": "Otomania feat. 初音ミク",
@@ -7616,9 +7120,7 @@
 		"title": "Gacha Gacha Cute Figu@mate"
 	},
 	{
-		"altTitles": [
-			"true my heart -Lovable mix-"
-		],
+		"altTitles": [],
 		"artist": "ave;new feat.Saori Sakura",
 		"data": {
 			"artistJP": "ave;new feat.佐倉紗織",
@@ -7630,9 +7132,7 @@
 		"title": "true my heart -Lovable mix-"
 	},
 	{
-		"altTitles": [
-			"Rodeo Machine"
-		],
+		"altTitles": [],
 		"artist": "HALFBY",
 		"data": {
 			"artistJP": "HALFBY",
@@ -7644,9 +7144,7 @@
 		"title": "Rodeo Machine"
 	},
 	{
-		"altTitles": [
-			"Arrival of Tears"
-		],
+		"altTitles": [],
 		"artist": "Ayane",
 		"data": {
 			"artistJP": "彩音",
@@ -7658,9 +7156,7 @@
 		"title": "Arrival of Tears"
 	},
 	{
-		"altTitles": [
-			"CYBER Sparks"
-		],
+		"altTitles": [],
 		"artist": "Tatsh",
 		"data": {
 			"artistJP": "Tatsh",
@@ -7672,9 +7168,7 @@
 		"title": "CYBER Sparks"
 	},
 	{
-		"altTitles": [
-			"Xevel"
-		],
+		"altTitles": [],
 		"artist": "Tatsh",
 		"data": {
 			"artistJP": "Tatsh",
@@ -7686,9 +7180,7 @@
 		"title": "Xevel"
 	},
 	{
-		"altTitles": [
-			"INFINITE WORLD"
-		],
+		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"artistJP": "SOUND HOLIC feat. Nana Takahashi",
@@ -7714,9 +7206,7 @@
 		"title": "SadoMamiHolic"
 	},
 	{
-		"altTitles": [
-			"Ragnarok"
-		],
+		"altTitles": [],
 		"artist": "sky_delta",
 		"data": {
 			"artistJP": "sky_delta",
@@ -7826,9 +7316,7 @@
 		"title": "Shinchoku Doudesuka?"
 	},
 	{
-		"altTitles": [
-			"Help me, あーりん！"
-		],
+		"altTitles": [],
 		"artist": "IRODORIMIDORI",
 		"data": {
 			"artistJP": "イロドリミドリ「CHUNITHM」",
@@ -7840,9 +7328,7 @@
 		"title": "Help me, あーりん！"
 	},
 	{
-		"altTitles": [
-			"なるとなぎのパーフェクトロックンロール教室"
-		],
+		"altTitles": [],
 		"artist": "IRODORIMIDORI",
 		"data": {
 			"artistJP": "イロドリミドリ「CHUNITHM」",
@@ -7854,9 +7340,7 @@
 		"title": "なるとなぎのパーフェクトロックンロール教室"
 	},
 	{
-		"altTitles": [
-			"あねぺったん"
-		],
+		"altTitles": [],
 		"artist": "Tsukisuzu Sisters“IRODORIMIDORI”",
 		"data": {
 			"artistJP": "月鈴姉妹（イロドリミドリ）",
@@ -7868,9 +7352,7 @@
 		"title": "あねぺったん"
 	},
 	{
-		"altTitles": [
-			"We Gonna Journey"
-		],
+		"altTitles": [],
 		"artist": "Queen P.A.L.",
 		"data": {
 			"artistJP": "Queen P.A.L.",
@@ -7882,9 +7364,7 @@
 		"title": "We Gonna Journey"
 	},
 	{
-		"altTitles": [
-			"FREEDOM DiVE (tpz Overcute Remix)"
-		],
+		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
 			"artistJP": "t+pazolite",
@@ -7896,9 +7376,7 @@
 		"title": "FREEDOM DiVE (tpz Overcute Remix)"
 	},
 	{
-		"altTitles": [
-			"SILENT BLUE"
-		],
+		"altTitles": [],
 		"artist": "Kaneko Chiharu",
 		"data": {
 			"artistJP": "かねこちはる",
@@ -7966,9 +7444,7 @@
 		"title": "Flower, snow and Drum'n'bass."
 	},
 	{
-		"altTitles": [
-			"Conquista Ciela"
-		],
+		"altTitles": [],
 		"artist": "Takenobu Mitsuyoshi“VIRTUAL-ON”",
 		"data": {
 			"artistJP": "光吉猛修「バーチャロン」",
@@ -8022,9 +7498,7 @@
 		"title": "ONEgai Darlin'"
 	},
 	{
-		"altTitles": [
-			"My First Phone"
-		],
+		"altTitles": [],
 		"artist": "cubesato",
 		"data": {
 			"artistJP": "cubesato",
@@ -8078,9 +7552,7 @@
 		"title": "NE!KO!"
 	},
 	{
-		"altTitles": [
-			"only my railgun"
-		],
+		"altTitles": [],
 		"artist": "fripSide",
 		"data": {
 			"artistJP": "fripSide",
@@ -8134,9 +7606,7 @@
 		"title": "ROKI"
 	},
 	{
-		"altTitles": [
-			"Money Money"
-		],
+		"altTitles": [],
 		"artist": "Akatsuki Records",
 		"data": {
 			"artistJP": "暁Records",
@@ -8162,9 +7632,7 @@
 		"title": "KYOKUKEN"
 	},
 	{
-		"altTitles": [
-			"Scarlet Lance"
-		],
+		"altTitles": [],
 		"artist": "MASAKI（ZUNTATA）「グルーヴコースター 3EX ドリームパーティー」より",
 		"data": {
 			"artistJP": "MASAKI（ZUNTATA）「グルーヴコースター 3EX ドリームパーティー」より",
@@ -8190,9 +7658,7 @@
 		"title": "Sacred Ruin"
 	},
 	{
-		"altTitles": [
-			"QZKago Requiem"
-		],
+		"altTitles": [],
 		"artist": "t+pazolite",
 		"data": {
 			"artistJP": "t+pazolite",
@@ -8204,9 +7670,7 @@
 		"title": "QZKago Requiem"
 	},
 	{
-		"altTitles": [
-			"EVERGREEN"
-		],
+		"altTitles": [],
 		"artist": "CRANKY",
 		"data": {
 			"artistJP": "Cranky",
@@ -8246,9 +7710,7 @@
 		"title": "Fusigi-no-kuni no Christmas"
 	},
 	{
-		"altTitles": [
-			"Schwarzschild"
-		],
+		"altTitles": [],
 		"artist": "Tsukasa",
 		"data": {
 			"artistJP": "Tsukasa",
@@ -8358,9 +7820,7 @@
 		"title": "Butterfly on your Right Shoulder"
 	},
 	{
-		"altTitles": [
-			"Alea jacta est!"
-		],
+		"altTitles": [],
 		"artist": "BlackY fused with WAiKURO",
 		"data": {
 			"artistJP": "BlackY fused with WAiKURO",
@@ -8428,9 +7888,7 @@
 		"title": "Inzen"
 	},
 	{
-		"altTitles": [
-			"White Traveling Girl"
-		],
+		"altTitles": [],
 		"artist": "A-One",
 		"data": {
 			"artistJP": "A-One",
@@ -8442,9 +7900,7 @@
 		"title": "White Traveling Girl"
 	},
 	{
-		"altTitles": [
-			"FFT"
-		],
+		"altTitles": [],
 		"artist": "cybermiso",
 		"data": {
 			"artistJP": "cybermiso",
@@ -8456,9 +7912,7 @@
 		"title": "FFT"
 	},
 	{
-		"altTitles": [
-			"-OutsideR:RequieM-"
-		],
+		"altTitles": [],
 		"artist": "Naru Hakobe (CV:M・A・O)",
 		"data": {
 			"artistJP": "箱部 なる(CV:M・A・O)",
@@ -8498,9 +7952,7 @@
 		"title": "Sosya ha tada senaka to violin de katarunomi"
 	},
 	{
-		"altTitles": [
-			"Deep in Abyss"
-		],
+		"altTitles": [],
 		"artist": "Riko(CV:Miyu Tomita)/Reg(CV:Mariya Ise)",
 		"data": {
 			"artistJP": "リコ（CV：富田美憂）、レグ（CV：伊瀬茉莉也）",
@@ -8526,9 +7978,7 @@
 		"title": "Raikiri"
 	},
 	{
-		"altTitles": [
-			"キミとボクのミライ"
-		],
+		"altTitles": [],
 		"artist": "Djeeta(CV:HisakoKanemoto)/Lyria(CV:NaoToyama)/Vira(CV:AsamiImai)/Mary(CV:TomokoHasegawa)",
 		"data": {
 			"artistJP": "ジータ（CV:金元寿子）、ルリア（CV:東山奈央）、ヴィーラ（CV:今井麻美）、マリー（CV:長谷川明子）",
@@ -8540,9 +7990,7 @@
 		"title": "キミとボクのミライ"
 	},
 	{
-		"altTitles": [
-			"Lost Princess"
-		],
+		"altTitles": [],
 		"artist": "Pecorine(CV:M・A・O)/Kokkoro(CV:MikiIto)/Kyaru(CV:RikaTachibana)",
 		"data": {
 			"artistJP": "ペコリーヌ（CV：M・A・O）、コッコロ（CV：伊藤美来）、キャル（CV：立花理香）",
@@ -8554,9 +8002,7 @@
 		"title": "Lost Princess"
 	},
 	{
-		"altTitles": [
-			"アリサのテーマ"
-		],
+		"altTitles": [],
 		"artist": "Yoshihiro Ike",
 		"data": {
 			"artistJP": "池頼広",
@@ -8624,9 +8070,7 @@
 		"title": "inochi bakkari"
 	},
 	{
-		"altTitles": [
-			"the EmpErroR"
-		],
+		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
 			"artistJP": "sasakure.UK",
@@ -8638,9 +8082,7 @@
 		"title": "the EmpErroR"
 	},
 	{
-		"altTitles": [
-			"PANDORA PARADOXXX"
-		],
+		"altTitles": [],
 		"artist": "Sakuzyo",
 		"data": {
 			"artistJP": "削除",
@@ -8652,9 +8094,7 @@
 		"title": "PANDORA PARADOXXX"
 	},
 	{
-		"altTitles": [
-			"Believe the Rainbow"
-		],
+		"altTitles": [],
 		"artist": "Shoichiro Hirata feat.Sana",
 		"data": {
 			"artistJP": "Shoichiro Hirata feat.Sana",
@@ -8666,9 +8106,7 @@
 		"title": "Believe the Rainbow"
 	},
 	{
-		"altTitles": [
-			"Good Bye, Mr. Jack"
-		],
+		"altTitles": [],
 		"artist": "sasakure.UK",
 		"data": {
 			"artistJP": "sasakure.UK",
@@ -8680,9 +8118,7 @@
 		"title": "Good Bye, Mr. Jack"
 	},
 	{
-		"altTitles": [
-			"Altale"
-		],
+		"altTitles": [],
 		"artist": "Sakuzyo",
 		"data": {
 			"artistJP": "削除",
@@ -8722,9 +8158,7 @@
 		"title": "Necrofantasia～Arr.Demetori"
 	},
 	{
-		"altTitles": [
-			"Imperishable Night 2006 (2016 Refine)"
-		],
+		"altTitles": [],
 		"artist": "yuuyu_ssry",
 		"data": {
 			"artistJP": "ゆうゆ / 篠螺悠那",
@@ -8750,9 +8184,7 @@
 		"title": "Shuuten"
 	},
 	{
-		"altTitles": [
-			"WORLD'S END UMBRELLA"
-		],
+		"altTitles": [],
 		"artist": "Hachi",
 		"data": {
 			"artistJP": "ハチ",
@@ -8778,9 +8210,7 @@
 		"title": "The “Wanderlast”"
 	},
 	{
-		"altTitles": [
-			"End Time"
-		],
+		"altTitles": [],
 		"artist": "Cres.",
 		"data": {
 			"artistJP": "Cres.",
@@ -8820,9 +8250,7 @@
 		"title": "I must transform to Magical-girl"
 	},
 	{
-		"altTitles": [
-			"Kattobi KEIKYU Rider"
-		],
+		"altTitles": [],
 		"artist": "Sampling Masters MEGA",
 		"data": {
 			"artistJP": "Sampling Masters MEGA",
@@ -8834,9 +8262,7 @@
 		"title": "Kattobi KEIKYU Rider"
 	},
 	{
-		"altTitles": [
-			"B.M.S."
-		],
+		"altTitles": [],
 		"artist": "Father of Takenobu Mitsuyoshi",
 		"data": {
 			"artistJP": "光吉猛修の父",
@@ -8848,9 +8274,7 @@
 		"title": "B.M.S."
 	},
 	{
-		"altTitles": [
-			"TiamaT:F minor"
-		],
+		"altTitles": [],
 		"artist": "Team Grimoire",
 		"data": {
 			"artistJP": "Team Grimoire",

--- a/database-seeds/scripts/rerunners/iidx/iidx-mdb-parse/blacklist.txt
+++ b/database-seeds/scripts/rerunners/iidx/iidx-mdb-parse/blacklist.txt
@@ -14,9 +14,3 @@ S16072$
 S16080$
 S16081$
 S16082$
-
-# there are two songs called Changes in omnimix. We support neither.
-# this is because it means we can't use songTitle as a matching thing
-# even though we really want to.
-S10029$
-S6211$

--- a/database-seeds/scripts/test/match-type.test.ts
+++ b/database-seeds/scripts/test/match-type.test.ts
@@ -74,6 +74,7 @@ for (const { game, matchType, playtype } of uniquenessChecks) {
 
 	let success = 0;
 	let fails = 0;
+	let warns = 0;
 
 	const data =
 		handler.type === "CHARTS"
@@ -100,15 +101,27 @@ for (const { game, matchType, playtype } of uniquenessChecks) {
 
 		for (const maybeUnique of newUniqueThingies) {
 			if (uniqueIDs.has(maybeUnique)) {
-				console.log(
-					chalk.red(
-						`ID ${maybeUnique} wasn't unique in ${FormatGame(
-							game,
-							playtype
-						)} (matchType=${matchType}). It needs to be for this matchType to be legal.`
-					)
-				);
-				fails++;
+				if (matchType === "songTitle") {
+					console.log(
+						chalk.yellow(
+							`Song title ${maybeUnique} wasn't unique in ${FormatGame(
+								game,
+								playtype
+							)}. Imports using this song title *will* have their scores rejected.`
+						)
+					);
+					warns++;
+				} else {
+					console.log(
+						chalk.red(
+							`ID ${maybeUnique} wasn't unique in ${FormatGame(
+								game,
+								playtype
+							)} (matchType=${matchType}). It needs to be for this matchType to be legal.`
+						)
+					);
+					fails++;
+				}
 			} else {
 				success++;
 				uniqueIDs.add(maybeUnique);
@@ -116,13 +129,15 @@ for (const { game, matchType, playtype } of uniquenessChecks) {
 		}
 	}
 
-	const report = `GOOD: ${success}, BAD: ${fails}(${Math.min(
-		(success * 100) / fails,
+	const report = `GOOD: ${success}, WARNS: ${warns}, BAD: ${fails}(${Math.min(
+		(success * 100) / (success + fails),
 		100
 	).toFixed(2)}%)`;
 	if (fails > 0) {
 		console.error(chalk.red(`[FAILED] ${name}. ${report}.`));
 		exitCode++;
+	} else if (warns > 0) {
+		console.error(chalk.yellow(`[GOOD ISH] ${name}. ${report}.`));
 	} else {
 		console.log(chalk.green(`[GOOD] ${name}. ${report}.`));
 	}

--- a/database-seeds/scripts/test/match-type.test.ts
+++ b/database-seeds/scripts/test/match-type.test.ts
@@ -81,9 +81,13 @@ for (const { game, matchType, playtype } of uniquenessChecks) {
 			: ReadCollection(`songs-${game}.json`);
 
 	const uniqueIDs = new Set();
-	for (const el of data.filter((e) => e.playtype === playtype)) {
+	for (const el of data) {
 		// skip non-primaries as they can't really be matched anyway.
 		if (handler.type === "CHARTS" && !el.isPrimary) {
+			continue;
+		}
+
+		if (handler.type === "CHARTS" && el.playtype !== playtype) {
 			continue;
 		}
 
@@ -123,7 +127,7 @@ for (const { game, matchType, playtype } of uniquenessChecks) {
 		console.log(chalk.green(`[GOOD] ${name}. ${report}.`));
 	}
 
-	suites.push({ name, report, good: fails === 0 });
+	suites.push({ name, report, good: success > 0 && fails === 0 });
 }
 
 console.log(`=== Suite Overview ===`);

--- a/server/src/lib/score-import/framework/common/converter-failures.ts
+++ b/server/src/lib/score-import/framework/common/converter-failures.ts
@@ -3,7 +3,12 @@
 import type { ImportTypeContextMap, ImportTypeDataMap } from "../../import-types/common/types";
 import type { ImportTypes } from "tachi-common";
 
-export type FailureTypes = "Internal" | "InvalidScore" | "SkipScore" | "SongOrChartNotFound";
+export type FailureTypes =
+	| "AmbiguousTitle"
+	| "Internal"
+	| "InvalidScore"
+	| "SkipScore"
+	| "SongOrChartNotFound";
 
 export class ConverterFailure extends Error {
 	message: string;
@@ -20,6 +25,16 @@ export class ConverterFailure extends Error {
 		// to stably assert what kind of error was thrown, we use a tagged string
 		// instead.
 		this.failureType = failureType;
+	}
+}
+
+/**
+ * AmbiguousTitleFailure - This score could not be processed because it uses the
+ * `songTitle` matching system, yet multiple songs share this title.
+ */
+export class AmbiguousTitleFailure extends ConverterFailure {
+	constructor(message: string) {
+		super(message, "AmbiguousTitle");
 	}
 }
 

--- a/server/src/lib/score-import/framework/common/converter-failures.ts
+++ b/server/src/lib/score-import/framework/common/converter-failures.ts
@@ -33,8 +33,12 @@ export class ConverterFailure extends Error {
  * `songTitle` matching system, yet multiple songs share this title.
  */
 export class AmbiguousTitleFailure extends ConverterFailure {
-	constructor(message: string) {
+	title: string;
+
+	constructor(songTitle: string, message: string) {
 		super(message, "AmbiguousTitle");
+
+		this.title = songTitle;
 	}
 }
 

--- a/server/src/lib/score-import/framework/score-importing/score-importing.ts
+++ b/server/src/lib/score-import/framework/score-importing/score-importing.ts
@@ -7,9 +7,13 @@ import { OrphanScore } from "../orphans/orphans";
 import db from "external/mongo/db";
 import { AppendLogCtx } from "lib/logger/logger";
 import { GetGPTString } from "tachi-common";
-import { ClassToObject, DeleteUndefinedProps } from "utils/misc";
+import { ClassToObject } from "utils/misc";
 import type { ConverterFnSuccessReturn, ConverterFunction } from "../../import-types/common/types";
-import type { ConverterFailure, SongOrChartNotFoundFailure } from "../common/converter-failures";
+import type {
+	AmbiguousTitleFailure,
+	ConverterFailure,
+	SongOrChartNotFoundFailure,
+} from "../common/converter-failures";
 import type { DryScore } from "../common/types";
 import type { KtLogger } from "lib/logger/logger";
 import type { ScoreImportJob } from "lib/score-import/worker/types";
@@ -220,6 +224,21 @@ export async function ImportIterableDatapoint<D, C>(
 					// could return cfnReturn.message here, but we might want to hide the details of the crash.
 					message: "An internal error has occured.",
 					content: {},
+				};
+			}
+
+			case "AmbiguousTitle": {
+				const atErr = err as AmbiguousTitleFailure;
+
+				logger.info(`AmbiguousTitleFailure: ${err.message}`, { err: ClassToObject(err) });
+
+				return {
+					type: "AmbiguousTitle",
+					success: false,
+					message: err.message,
+					content: {
+						title: atErr.title,
+					},
 				};
 			}
 

--- a/server/src/utils/queries/songs.ts
+++ b/server/src/utils/queries/songs.ts
@@ -36,6 +36,7 @@ export async function FindSongOnTitle(game: Game, title: string): Promise<SongDo
 
 	if (res.length === 2) {
 		throw new AmbiguousTitleFailure(
+			title,
 			`Multiple songs exist with the title ${title}. We cannot resolve this. Please try and use a different song resolution method.`
 		);
 	}
@@ -73,6 +74,7 @@ export async function FindSongOnTitleInsensitive(
 
 	if (res.length === 2) {
 		throw new AmbiguousTitleFailure(
+			title,
 			`Multiple songs exist with the case-insensitive title ${title}. We cannot resolve this. Please try and use a different song resolution method.`
 		);
 	}

--- a/server/src/utils/queries/songs.ts
+++ b/server/src/utils/queries/songs.ts
@@ -1,6 +1,9 @@
 import { EscapeStringRegexp } from "../misc";
 import db from "external/mongo/db";
-import { InternalFailure } from "lib/score-import/framework/common/converter-failures";
+import {
+	AmbiguousTitleFailure,
+	InternalFailure,
+} from "lib/score-import/framework/common/converter-failures";
 import type { KtLogger } from "lib/logger/logger";
 import type { FindOneResult } from "monk";
 import type { Game, integer, SongDocument } from "tachi-common";
@@ -13,42 +16,68 @@ import type { Game, integer, SongDocument } from "tachi-common";
  * @param title - The song title to match.
  * @returns SongDocument
  */
-export function FindSongOnTitle(game: Game, title: string): Promise<FindOneResult<SongDocument>> {
+export async function FindSongOnTitle(game: Game, title: string): Promise<SongDocument | null> {
 	// @optimisable: Performance should be tested here by having a utility field for all-titles.
-	return db.anySongs[game].findOne({
-		$or: [
-			{
-				title,
-			},
-			{
-				altTitles: title,
-			},
-		],
-	});
+	const res = await db.anySongs[game].find(
+		{
+			$or: [
+				{
+					title,
+				},
+				{
+					altTitles: title,
+				},
+			],
+		},
+		{
+			limit: 2,
+		}
+	);
+
+	if (res.length === 2) {
+		throw new AmbiguousTitleFailure(
+			`Multiple songs exist with the title ${title}. We cannot resolve this. Please try and use a different song resolution method.`
+		);
+	}
+
+	return res[0] ?? null;
 }
 
 /**
  * Finds a song on a song title case-insensitively.
  * This is needed for services that provide horrifically mutated string titles.
  */
-export function FindSongOnTitleInsensitive(
+export async function FindSongOnTitleInsensitive(
 	game: Game,
 	title: string
-): Promise<FindOneResult<SongDocument>> {
+): Promise<SongDocument | null> {
 	// @optimisable: Performance should be tested here by having a utility field for all-titles.
 
 	const regex = new RegExp(`^${EscapeStringRegexp(title)}$`, "iu");
 
-	return db.anySongs[game].findOne({
-		$or: [
-			{
-				title: { $regex: regex },
-			},
-			{
-				altTitles: { $regex: regex },
-			},
-		],
-	});
+	const res = await db.anySongs[game].find(
+		{
+			$or: [
+				{
+					title: { $regex: regex },
+				},
+				{
+					altTitles: { $regex: regex },
+				},
+			],
+		},
+		{
+			limit: 2,
+		}
+	);
+
+	if (res.length === 2) {
+		throw new AmbiguousTitleFailure(
+			`Multiple songs exist with the case-insensitive title ${title}. We cannot resolve this. Please try and use a different song resolution method.`
+		);
+	}
+
+	return res[0] ?? null;
 }
 
 /**


### PR DESCRIPTION
I made the duplicate-song-title-checker work, but it's revealed that we have a hell of a lot of duplicate song titles in the database. This needs to be sorted out one way or another.

We have a fairly frustrating issue which is that the eamusement CSV imports use song title matching, but they *can't* because there are duplicate song titles in the games-in-question. This sucks, we need to do this abstraction better. Sad.