### PR TITLE
feat: IIDX metadata update

### DIFF
--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -26439,8 +26439,11 @@
 			"genre": "NEOTRANCE CORE"
 		},
 		"id": 2365,
-		"searchTerms": [],
-		"title": "ACT?"
+		"searchTerms": [
+			"ACT0",
+			"Act"
+		],
+		"title": "ACTØ"
 	},
 	{
 		"altTitles": [],

--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -26432,7 +26432,9 @@
 		"title": "TRIP THE DEEP"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"ACT0"
+		],
 		"artist": "モリモリあつし",
 		"data": {
 			"displayVersion": "31",

--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -26351,7 +26351,9 @@
 			"genre": "IIDX EDITION"
 		},
 		"id": 2357,
-		"searchTerms": [],
+		"searchTerms": [
+			"Yoidore shirazu"
+		],
 		"title": "酔いどれ知らず"
 	},
 	{
@@ -26384,7 +26386,9 @@
 			"genre": "PROLOGUE"
 		},
 		"id": 2360,
-		"searchTerms": [],
+		"searchTerms": [
+			"Planetary Express"
+		],
 		"title": "惑星鉄道"
 	},
 	{
@@ -26406,7 +26410,9 @@
 			"genre": "ALTERNATIVE"
 		},
 		"id": 2362,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kamisama, Tsurenai"
+		],
 		"title": "神様、つれない。"
 	},
 	{
@@ -26417,7 +26423,9 @@
 			"genre": "BREAKCORE"
 		},
 		"id": 2363,
-		"searchTerms": [],
+		"searchTerms": [
+			"Dennou Toshi"
+		],
 		"title": "電腦都市"
 	},
 	{
@@ -26477,7 +26485,9 @@
 			"genre": "J-POP"
 		},
 		"id": 2368,
-		"searchTerms": [],
+		"searchTerms": [
+			"Show"
+		],
 		"title": "唱"
 	},
 	{
@@ -26488,7 +26498,9 @@
 			"genre": "IIDX EDITION"
 		},
 		"id": 2369,
-		"searchTerms": [],
+		"searchTerms": [
+			"Yuusha"
+		],
 		"title": "勇者"
 	},
 	{
@@ -26499,7 +26511,9 @@
 			"genre": "IIDX EDITION"
 		},
 		"id": 2370,
-		"searchTerms": [],
+		"searchTerms": [
+			"Marshall Maximizer"
+		],
 		"title": "マーシャル・マキシマイザー"
 	}
 ]

--- a/database-seeds/collections/songs-iidx.json
+++ b/database-seeds/collections/songs-iidx.json
@@ -26309,5 +26309,192 @@
 			"Note Highway"
 		],
 		"title": "Note Highway ft. KANASA from bless4"
+	},
+	{
+		"altTitles": [],
+		"artist": "lapix ∞ BEMANI Sound Team \"L.E.D.\"",
+		"data": {
+			"displayVersion": "31",
+			"genre": "PSYCHEDELIC TRANCE"
+		},
+		"id": 2354,
+		"searchTerms": [],
+		"title": "CADENZA"
+	},
+	{
+		"altTitles": [],
+		"artist": "sky_delta",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HI-SPEED TECHCORE"
+		},
+		"id": 2355,
+		"searchTerms": [],
+		"title": "Sword of Vengeance"
+	},
+	{
+		"altTitles": [],
+		"artist": "BlackY",
+		"data": {
+			"displayVersion": "31",
+			"genre": "TRANCE"
+		},
+		"id": 2356,
+		"searchTerms": [],
+		"title": "Amethyst"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by SOUND HOLIC feat. Nana Takahashi",
+		"data": {
+			"displayVersion": "31",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2357,
+		"searchTerms": [],
+		"title": "酔いどれ知らず"
+	},
+	{
+		"altTitles": [],
+		"artist": "Xceon",
+		"data": {
+			"displayVersion": "31",
+			"genre": "SYMPHONIC DRUM'N'BASS"
+		},
+		"id": 2358,
+		"searchTerms": [],
+		"title": "COUNTING SHEEP ft. Kanae Asaba"
+	},
+	{
+		"altTitles": [],
+		"artist": "MK & RoughSketch",
+		"data": {
+			"displayVersion": "31",
+			"genre": "HARD TECHNO/DOWNTEMPO"
+		},
+		"id": 2359,
+		"searchTerms": [],
+		"title": "Stereo Beasts"
+	},
+	{
+		"altTitles": [],
+		"artist": "Snail's House",
+		"data": {
+			"displayVersion": "31",
+			"genre": "PROLOGUE"
+		},
+		"id": 2360,
+		"searchTerms": [],
+		"title": "惑星鉄道"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nhato",
+		"data": {
+			"displayVersion": "31",
+			"genre": "CINEMATIC BREAKCORE"
+		},
+		"id": 2361,
+		"searchTerms": [],
+		"title": "Demon March"
+	},
+	{
+		"altTitles": [],
+		"artist": "中山真斗 feat. CHAN",
+		"data": {
+			"displayVersion": "31",
+			"genre": "ALTERNATIVE"
+		},
+		"id": 2362,
+		"searchTerms": [],
+		"title": "神様、つれない。"
+	},
+	{
+		"altTitles": [],
+		"artist": "Blacklolita",
+		"data": {
+			"displayVersion": "31",
+			"genre": "BREAKCORE"
+		},
+		"id": 2363,
+		"searchTerms": [],
+		"title": "電腦都市"
+	},
+	{
+		"altTitles": [],
+		"artist": "Qlarabelle",
+		"data": {
+			"displayVersion": "31",
+			"genre": "MELODIC TECHNO"
+		},
+		"id": 2364,
+		"searchTerms": [],
+		"title": "TRIP THE DEEP"
+	},
+	{
+		"altTitles": [],
+		"artist": "モリモリあつし",
+		"data": {
+			"displayVersion": "31",
+			"genre": "NEOTRANCE CORE"
+		},
+		"id": 2365,
+		"searchTerms": [],
+		"title": "ACT?"
+	},
+	{
+		"altTitles": [],
+		"artist": "Maozon",
+		"data": {
+			"displayVersion": "31",
+			"genre": "CYBER DRUMSTEP"
+		},
+		"id": 2366,
+		"searchTerms": [],
+		"title": "Just Gimme"
+	},
+	{
+		"altTitles": [],
+		"artist": "Dirty Androids",
+		"data": {
+			"displayVersion": "31",
+			"genre": "PARTICULAR NIGHTSCAPE"
+		},
+		"id": 2367,
+		"searchTerms": [],
+		"title": "Million Dollar"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ado",
+		"data": {
+			"displayVersion": "31",
+			"genre": "J-POP"
+		},
+		"id": 2368,
+		"searchTerms": [],
+		"title": "唱"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by OSTER project feat. そらこ",
+		"data": {
+			"displayVersion": "31",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2369,
+		"searchTerms": [],
+		"title": "勇者"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by uno(IOSYS) feat. Chiyoko",
+		"data": {
+			"displayVersion": "31",
+			"genre": "IIDX EDITION"
+		},
+		"id": 2370,
+		"searchTerms": [],
+		"title": "マーシャル・マキシマイザー"
 	}
 ]


### PR DESCRIPTION
This adds newer tier info from atwiki and updates the iidx31 seeds.

Note that a song added in iidx31 has been removed, this is handled by having an empty `versions` array.