### PR TITLE
[chunithm] Update seeds to 2024/07/04 and fix versions for some ULTIMA charts

### DIFF
--- a/database-seeds/collections/charts-chunithm.json
+++ b/database-seeds/collections/charts-chunithm.json
@@ -388,7 +388,6 @@
 		"playtype": "Single",
 		"songID": 6,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -969,8 +968,6 @@
 		"playtype": "Single",
 		"songID": 18,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-omni",
 			"sunplus",
@@ -1199,8 +1196,6 @@
 		"playtype": "Single",
 		"songID": 20,
 		"versions": [
-			"new",
-			"newplus",
 			"luminous",
 			"luminous-omni"
 		]
@@ -2149,8 +2144,6 @@
 		"playtype": "Single",
 		"songID": 37,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-omni",
 			"sunplus",
@@ -2275,8 +2268,6 @@
 		"playtype": "Single",
 		"songID": 38,
 		"versions": [
-			"new",
-			"newplus",
 			"sunplus",
 			"sunplus-omni",
 			"luminous",
@@ -2720,7 +2711,6 @@
 		"playtype": "Single",
 		"songID": 45,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -3082,8 +3072,6 @@
 		"playtype": "Single",
 		"songID": 48,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-intl",
 			"sun-omni",
@@ -4371,7 +4359,6 @@
 		"playtype": "Single",
 		"songID": 63,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -4604,7 +4591,6 @@
 		"playtype": "Single",
 		"songID": 65,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -4837,8 +4823,6 @@
 		"playtype": "Single",
 		"songID": 67,
 		"versions": [
-			"new",
-			"newplus",
 			"sunplus",
 			"sunplus-intl",
 			"sunplus-omni",
@@ -5612,7 +5596,6 @@
 		"playtype": "Single",
 		"songID": 74,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -5741,8 +5724,6 @@
 		"playtype": "Single",
 		"songID": 75,
 		"versions": [
-			"new",
-			"newplus",
 			"luminous",
 			"luminous-intl",
 			"luminous-omni"
@@ -6456,8 +6437,6 @@
 		"playtype": "Single",
 		"songID": 83,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-intl",
 			"sun-omni",
@@ -7626,8 +7605,6 @@
 		"playtype": "Single",
 		"songID": 95,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-intl",
 			"sun-omni",
@@ -7963,7 +7940,6 @@
 		"playtype": "Single",
 		"songID": 98,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -9445,8 +9421,6 @@
 		"playtype": "Single",
 		"songID": 113,
 		"versions": [
-			"new",
-			"newplus",
 			"luminous",
 			"luminous-intl",
 			"luminous-omni"
@@ -9952,7 +9926,6 @@
 		"playtype": "Single",
 		"songID": 118,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -11169,8 +11142,6 @@
 		"playtype": "Single",
 		"songID": 132,
 		"versions": [
-			"new",
-			"newplus",
 			"sun-omni",
 			"sunplus",
 			"sunplus-intl",
@@ -11908,7 +11879,6 @@
 		"playtype": "Single",
 		"songID": 140,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -12245,7 +12215,6 @@
 		"playtype": "Single",
 		"songID": 143,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -13247,7 +13216,6 @@
 		"playtype": "Single",
 		"songID": 152,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -13828,8 +13796,6 @@
 		"playtype": "Single",
 		"songID": 159,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-omni",
 			"sunplus",
@@ -14164,7 +14130,6 @@
 		"playtype": "Single",
 		"songID": 163,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -14397,8 +14362,6 @@
 		"playtype": "Single",
 		"songID": 166,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-intl",
 			"sun-omni",
@@ -14646,8 +14609,6 @@
 		"playtype": "Single",
 		"songID": 168,
 		"versions": [
-			"new",
-			"newplus",
 			"luminous",
 			"luminous-intl",
 			"luminous-omni"
@@ -14769,8 +14730,6 @@
 		"playtype": "Single",
 		"songID": 169,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-intl",
 			"sun-omni",
@@ -15106,8 +15065,6 @@
 		"playtype": "Single",
 		"songID": 173,
 		"versions": [
-			"new",
-			"newplus",
 			"luminous",
 			"luminous-omni"
 		]
@@ -16224,7 +16181,6 @@
 		"playtype": "Single",
 		"songID": 187,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -21208,8 +21164,6 @@
 		"playtype": "Single",
 		"songID": 244,
 		"versions": [
-			"new",
-			"newplus",
 			"sunplus",
 			"sunplus-omni",
 			"luminous",
@@ -26704,8 +26658,6 @@
 		"playtype": "Single",
 		"songID": 298,
 		"versions": [
-			"new",
-			"newplus",
 			"luminous",
 			"luminous-intl",
 			"luminous-omni"
@@ -28476,8 +28428,6 @@
 		"playtype": "Single",
 		"songID": 317,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-intl",
 			"sun-omni",
@@ -29125,8 +29075,6 @@
 		"playtype": "Single",
 		"songID": 323,
 		"versions": [
-			"new",
-			"newplus",
 			"sunplus",
 			"sunplus-intl",
 			"sunplus-omni",
@@ -29867,8 +29815,6 @@
 		"playtype": "Single",
 		"songID": 330,
 		"versions": [
-			"new",
-			"newplus",
 			"sunplus",
 			"sunplus-intl",
 			"sunplus-omni",
@@ -29993,8 +29939,6 @@
 		"playtype": "Single",
 		"songID": 331,
 		"versions": [
-			"new",
-			"newplus",
 			"sunplus",
 			"sunplus-intl",
 			"sunplus-omni",
@@ -37128,7 +37072,6 @@
 		"playtype": "Single",
 		"songID": 417,
 		"versions": [
-			"new",
 			"newplus",
 			"sun-omni",
 			"sunplus-omni",
@@ -40742,7 +40685,6 @@
 		"playtype": "Single",
 		"songID": 462,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -50167,8 +50109,6 @@
 		"playtype": "Single",
 		"songID": 574,
 		"versions": [
-			"new",
-			"newplus",
 			"sunplus",
 			"sunplus-omni",
 			"luminous",
@@ -70536,8 +70476,6 @@
 		"playtype": "Single",
 		"songID": 807,
 		"versions": [
-			"new",
-			"newplus",
 			"luminous",
 			"luminous-intl",
 			"luminous-omni"
@@ -71527,8 +71465,6 @@
 		"playtype": "Single",
 		"songID": 818,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-omni",
 			"sunplus",
@@ -71654,8 +71590,6 @@
 		"playtype": "Single",
 		"songID": 819,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-intl",
 			"sun-omni",
@@ -73759,7 +73693,6 @@
 		"playtype": "Single",
 		"songID": 840,
 		"versions": [
-			"new",
 			"newplus",
 			"sun",
 			"sun-intl",
@@ -78344,8 +78277,6 @@
 		"playtype": "Single",
 		"songID": 887,
 		"versions": [
-			"new",
-			"newplus",
 			"sun",
 			"sun-intl",
 			"sun-omni",
@@ -147211,6 +147142,7 @@
 		"songID": 2574,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147227,6 +147159,7 @@
 		"songID": 2574,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147243,6 +147176,7 @@
 		"songID": 2574,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147259,6 +147193,7 @@
 		"songID": 2574,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147275,6 +147210,7 @@
 		"songID": 2575,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147291,6 +147227,7 @@
 		"songID": 2575,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147307,6 +147244,7 @@
 		"songID": 2575,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147323,6 +147261,7 @@
 		"songID": 2575,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147339,6 +147278,7 @@
 		"songID": 2576,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147355,6 +147295,7 @@
 		"songID": 2576,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147371,6 +147312,7 @@
 		"songID": 2576,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147387,6 +147329,7 @@
 		"songID": 2576,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147403,6 +147346,7 @@
 		"songID": 2577,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147419,6 +147363,7 @@
 		"songID": 2577,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147435,6 +147380,7 @@
 		"songID": 2577,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147451,6 +147397,7 @@
 		"songID": 2577,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147467,6 +147414,7 @@
 		"songID": 2578,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147483,6 +147431,7 @@
 		"songID": 2578,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147499,6 +147448,7 @@
 		"songID": 2578,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},
@@ -147515,6 +147465,7 @@
 		"songID": 2578,
 		"versions": [
 			"luminous",
+			"luminous-intl",
 			"luminous-omni"
 		]
 	},

--- a/database-seeds/scripts/rerunners/chunithm/merge-options.ts
+++ b/database-seeds/scripts/rerunners/chunithm/merge-options.ts
@@ -80,7 +80,10 @@ if (require.main !== module) {
 }
 
 const program = new Command()
-	.requiredOption("-i, --input <OPTIONS DIRS...>", "The options directories of your CHUNITHM install. Typically App/data and Option.")
+	.requiredOption(
+		"-i, --input <OPTIONS DIRS...>",
+		"The options directories of your CHUNITHM install. Typically App/data and Option."
+	)
 	.requiredOption("-v, --version <VERSION>", "The version of this CHUNITHM install.")
 	.option("-f, --force", "Forces overwrites where it shouldn't be done automatically.")
 	.parse(process.argv);
@@ -91,17 +94,17 @@ const tachiVersions = Object.keys(GetGamePTConfig("chunithm", "Single").versions
 
 if (!VERSIONS.includes(baseVersion)) {
 	throw new Error(
-		`Invalid base version ${baseVersion}. Expected any of ${
-			VERSIONS.join(",")
-		}. Update the VERSIONS array in database-seeds/scripts/rerunners/chunithm/merge-options.ts.`
+		`Invalid base version ${baseVersion}. Expected any of ${VERSIONS.join(
+			","
+		)}. Update the VERSIONS array in database-seeds/scripts/rerunners/chunithm/merge-options.ts.`
 	);
 }
 
 if (!tachiVersions.includes(options.version)) {
 	throw new Error(
-		`Invalid version ${options.version}. Expected any of ${
-			tachiVersions.join(",")
-		}. If you're adding a new version, go update common/src/config/game-config/chunithm.ts.`
+		`Invalid version ${options.version}. Expected any of ${tachiVersions.join(
+			","
+		)}. If you're adding a new version, go update common/src/config/game-config/chunithm.ts.`
 	);
 }
 
@@ -109,7 +112,8 @@ const isOmnimixVersion = /-omni$/u.test(options.version);
 const isLatestVersion = VERSIONS.indexOf(baseVersion) === VERSIONS.length - 1;
 
 const existingSongDocs: Array<SongDocument<"chunithm">> = ReadCollection("songs-chunithm.json");
-const existingChartDocs: Array<ChartDocument<"chunithm:Single">> = ReadCollection("charts-chunithm.json");
+const existingChartDocs: Array<ChartDocument<"chunithm:Single">> =
+	ReadCollection("charts-chunithm.json");
 
 const songMap = new Map(existingSongDocs.map((s) => [s.id, s]));
 const songTitleMap = new Map(existingSongDocs.map((s) => [s.title, s]));
@@ -129,7 +133,9 @@ const newCharts: Array<ChartDocument<"chunithm:Single">> = [];
 for (const optionsDir of options.input) {
 	for (const option of readdirSync(optionsDir)) {
 		if (!isOmnimixVersion && OMNIMIX_OPTION_NAMES.includes(option)) {
-			logger.warn(`Ignoring omnimix option ${option} because the version specified is not an omnimix version.`);
+			logger.warn(
+				`Ignoring omnimix option ${option} because the version specified is not an omnimix version.`
+			);
 			continue;
 		}
 
@@ -149,9 +155,9 @@ for (const optionsDir of options.input) {
 
 		for (const music of readdirSync(musicsDir)) {
 			const musicDir = path.join(musicsDir, music);
-		
-			if (!/music\d+$/.test(music)) {
-				continue
+
+			if (!/music\d+$/u.test(music)) {
+				continue;
 			}
 
 			if (!statSync(musicDir).isDirectory()) {
@@ -182,11 +188,7 @@ for (const optionsDir of options.input) {
 			if (musicData.disableFlag) {
 				if (tachiSongID !== undefined) {
 					logger.info(
-						`Removing charts of song ${musicData.artistName.str} - ${
-							musicData.name.str
-						} (ID ${tachiSongID}) from version ${
-							options.version
-						}, because disableFlag is enabled.`
+						`Removing charts of song ${musicData.artistName.str} - ${musicData.name.str} (ID ${tachiSongID}) from version ${options.version}, because disableFlag is enabled.`
 					);
 
 					existingChartDocs
@@ -209,10 +211,8 @@ for (const optionsDir of options.input) {
 
 				if (existingTitle) {
 					logger.warn(
-						`A song called ${musicData.name.str} already exists in songs-chunithm (ID ${
-							existingTitle.id
-						}). Is this a duplicate with a given inGameID?`,
-					)
+						`A song called ${musicData.name.str} already exists in songs-chunithm (ID ${existingTitle.id}). Is this a duplicate with a given inGameID?`
+					);
 
 					if (options.force) {
 						logger.warn("--force was requested, adding this song anyways.");
@@ -225,12 +225,10 @@ for (const optionsDir of options.input) {
 				tachiSongID = musicData.name.id;
 
 				const displayVersion = VERSIONS[musicData.releaseTagName.id];
-				
+
 				if (!displayVersion) {
 					throw new Error(
-						`Unknown version ID ${
-							musicData.releaseTagName.id
-						}. Update database-seeds/scripts/rerunners/chunithm/merge-options.ts.`
+						`Unknown version ID ${musicData.releaseTagName.id}. Update database-seeds/scripts/rerunners/chunithm/merge-options.ts.`
 					);
 				}
 
@@ -245,13 +243,15 @@ for (const optionsDir of options.input) {
 						genre: musicData.genreNames.list.StringID.str,
 					},
 				};
-	
+
 				newSongs.push(songDoc);
 				inGameIDToSongIDMap.set(inGameID, tachiSongID);
 
 				logger.info(`Added new song ${songDoc.artist} - ${songDoc.title}.`);
 			} else if (!songMap.has(tachiSongID)) {
-				throw new Error(`CONSISTENCY ERROR: Song ID ${tachiSongID} does not belong to any songs!`);
+				throw new Error(
+					`CONSISTENCY ERROR: Song ID ${tachiSongID} does not belong to any songs!`
+				);
 			}
 
 			for (const difficulty of musicData.fumens.MusicFumenData) {
@@ -267,25 +267,31 @@ for (const optionsDir of options.input) {
 
 					if (!difficulty.enable) {
 						if (versionIndex !== -1) {
-							logger.info(`Removing ${displayName} from version ${options.version} because it has been disabled.`);
+							logger.info(
+								`Removing ${displayName} from version ${options.version} because it has been disabled.`
+							);
 							exists.versions.splice(versionIndex, 1);
 						}
-						
+
 						continue;
 					}
 
 					if (versionIndex === -1) {
-						logger.info(`Adding ${displayName} to version ${options.version}.`)
+						logger.info(`Adding ${displayName} to version ${options.version}.`);
 						exists.versions.push(options.version);
 					}
 
 					if (isLatestVersion && exists.level !== level) {
-						logger.info(`Chart ${displayName} has had a level change: ${exists.level} -> ${level}`);
+						logger.info(
+							`Chart ${displayName} has had a level change: ${exists.level} -> ${level}`
+						);
 						exists.level = level;
 					}
 
 					if (isLatestVersion && exists.levelNum !== levelNum) {
-						logger.info(`Chart ${displayName} has had a levelNum change: ${exists.levelNum} -> ${levelNum}`);
+						logger.info(
+							`Chart ${displayName} has had a levelNum change: ${exists.levelNum} -> ${levelNum}`
+						);
 						exists.levelNum = levelNum;
 					}
 
@@ -298,9 +304,7 @@ for (const optionsDir of options.input) {
 
 				if (difficultyName === "WORLD'S END") {
 					logger.warn(
-						`Song ${musicData.artistName.str} - ${
-							musicData.name.str
-						} (inGameID=${musicData.name.id}) contains a WORLD'S END chart, which should be impossible. Refusing to process this difficulty.`
+						`Song ${musicData.artistName.str} - ${musicData.name.str} (inGameID=${musicData.name.id}) contains a WORLD'S END chart, which should be impossible. Refusing to process this difficulty.`
 					);
 					continue;
 				}
@@ -318,10 +322,12 @@ for (const optionsDir of options.input) {
 						inGameID,
 					},
 				};
-				
+
 				newCharts.push(chartDoc);
 
-				logger.info(`Added chart ${musicData.artistName.str} - ${musicData.name.str} [${difficultyName}] (${chartDoc.chartID}).`);
+				logger.info(
+					`Added chart ${musicData.artistName.str} - ${musicData.name.str} [${difficultyName}] (${chartDoc.chartID}).`
+				);
 			}
 		}
 	}


### PR DESCRIPTION
- Adds LUMINOUS ep. II to LUMINOUS International: https://info-chunithm.sega.com/2779/
- Remove ULTIMA charts introduced in later versions from NEW/NEW+