### PR TITLE
fix(ongeki): set isReMaster for a few charts

### DIFF
--- a/database-seeds/collections/charts-ongeki.json
+++ b/database-seeds/collections/charts-ongeki.json
@@ -123,7 +123,7 @@
 		"data": {
 			"displayVersion": "bright MEMORY",
 			"inGameID": 8162,
-			"isReMaster": false,
+			"isReMaster": true,
 			"maxPlatScore": 2340
 		},
 		"difficulty": "LUNATIC",
@@ -209,7 +209,7 @@
 		"data": {
 			"displayVersion": "R.E.D. PLUS",
 			"inGameID": 8058,
-			"isReMaster": false,
+			"isReMaster": true,
 			"maxPlatScore": 3014
 		},
 		"difficulty": "LUNATIC",
@@ -295,7 +295,7 @@
 		"data": {
 			"displayVersion": "オンゲキ PLUS",
 			"inGameID": 8022,
-			"isReMaster": false,
+			"isReMaster": true,
 			"maxPlatScore": 2396
 		},
 		"difficulty": "LUNATIC",
@@ -2351,7 +2351,7 @@
 		"data": {
 			"displayVersion": "bright",
 			"inGameID": 8067,
-			"isReMaster": false,
+			"isReMaster": true,
 			"maxPlatScore": 2234
 		},
 		"difficulty": "LUNATIC",
@@ -16481,7 +16481,7 @@
 		"data": {
 			"displayVersion": "bright MEMORY",
 			"inGameID": 8083,
-			"isReMaster": false,
+			"isReMaster": true,
 			"maxPlatScore": 3558
 		},
 		"difficulty": "LUNATIC",


### PR DESCRIPTION
Act.3 split Lunatic charts into LUNATIC and Re:MASTER folders. The latter is supposed to consist of the "normal" charts.

The charts affected in this commit were removed before Act.3, but I believe they match the intent behind Re:MASTER. They don't have any major gimmicks or other pecularities that warrant being in the Act.3 LUNATIC folder.

This is for the sake of consistency in the omnimix folders (non-omnimix folders are unaffected).

List:
* [シュガーソングとビターステップ](https://wikiwiki.jp/gameongeki/%E3%82%B7%E3%83%A5%E3%82%AC%E3%83%BC%E3%82%BD%E3%83%B3%E3%82%B0%E3%81%A8%E3%83%93%E3%82%BF%E3%83%BC%E3%82%B9%E3%83%86%E3%83%83%E3%83%97)
* [回レ！雪月花](https://wikiwiki.jp/gameongeki/%E5%9B%9E%E3%83%AC%EF%BC%81%E9%9B%AA%E6%9C%88%E8%8A%B1)
* [ようこそジャパリパークへ](https://wikiwiki.jp/gameongeki/%E3%82%88%E3%81%86%E3%81%93%E3%81%9D%E3%82%B8%E3%83%A3%E3%83%91%E3%83%AA%E3%83%91%E3%83%BC%E3%82%AF%E3%81%B8)
* [ブリキノダンス](https://wikiwiki.jp/gameongeki/%E3%83%96%E3%83%AA%E3%82%AD%E3%83%8E%E3%83%80%E3%83%B3%E3%82%B9)
* [永遠メモリー](https://wikiwiki.jp/gameongeki/%E6%B0%B8%E9%81%A0%E3%83%A1%E3%83%A2%E3%83%AA%E3%83%BC)

This decreases the size of "LUNATIC (bright MEMORY Act.3 Omnimix)" down to 39.
