### PR TITLE
fix: do not delete PB after reverting import

### DIFF
--- a/server/src/lib/score-mutation/delete-scores.ts
+++ b/server/src/lib/score-mutation/delete-scores.ts
@@ -199,7 +199,7 @@ export async function DeleteMultipleScores(scores: Array<ScoreDocument>, blackli
 	for (const score of scores) {
 		const userHasOtherScores = await db.scores.findOne({
 			userID: score.userID,
-			chart: score.chartID,
+			chartID: score.chartID,
 		});
 
 		if (userHasOtherScores) {


### PR DESCRIPTION
closes #1129. fix tested on a local instance using the same reproduction steps as the linked issue.