### PR TITLE
feat: disable score validation by judgement for DDR

### DIFF
--- a/server/src/game-implementations/games/ddr.ts
+++ b/server/src/game-implementations/games/ddr.ts
@@ -62,34 +62,40 @@ const DDR_GOAL_PG_FMT: GPTGoalProgressFormatters<"ddr:DP" | "ddr:SP"> = {
 };
 
 export const DDR_SCORE_VALIDATORS: Array<ScoreValidator<"ddr:DP" | "ddr:SP">> = [
-	(s) => {
-		const { MARVELOUS, PERFECT, GREAT, GOOD, OK, MISS } = s.scoreData.judgements;
-
-		if (
-			IsNullish(MARVELOUS) ||
-			IsNullish(PERFECT) ||
-			IsNullish(GREAT) ||
-			IsNullish(GOOD) ||
-			IsNullish(OK) ||
-			IsNullish(MISS)
-		) {
-			return;
-		}
-
-		const stepScore = 1_000_000 / (MARVELOUS + PERFECT + GREAT + GOOD + OK + MISS);
-		const calculatedScore =
-			Math.floor(
-				(stepScore * (MARVELOUS + OK) +
-					(stepScore - 10) * PERFECT +
-					((stepScore * 3) / 5 - 10) * GREAT +
-					(stepScore / 5 - 10) * GOOD) /
-					10
-			) * 10;
-
-		if (calculatedScore !== s.scoreData.score) {
-			return `Expected calculated score from judgements of ${calculatedScore} to equal score of ${s.scoreData.score}.`;
-		}
-	},
+	// Score validation with judgements is disabled until we have stepCount + holdCount for every chart.
+	// Using the sum of all judgements does not work in case of missed holds.
+	// (s) => {
+	// if (s.scoreData.lamp === "FAILED") {
+	// return;
+	// }
+	//
+	// const { MARVELOUS, PERFECT, GREAT, GOOD, OK, MISS } = s.scoreData.judgements;
+	//
+	// if (
+	// IsNullish(MARVELOUS) ||
+	// IsNullish(PERFECT) ||
+	// IsNullish(GREAT) ||
+	// IsNullish(GOOD) ||
+	// IsNullish(OK) ||
+	// IsNullish(MISS)
+	// ) {
+	// return;
+	// }
+	//
+	// const stepScore = 1_000_000 / (MARVELOUS + PERFECT + GREAT + GOOD + OK + MISS);
+	// const calculatedScore =
+	// Math.floor(
+	// (stepScore * (MARVELOUS + OK) +
+	// 				(stepScore - 10) * PERFECT +
+	// 				((stepScore * 3) / 5 - 10) * GREAT +
+	// 				(stepScore / 5 - 10) * GOOD) /
+	// 				10
+	// ) * 10;
+	//
+	// if (calculatedScore !== s.scoreData.score) {
+	// return `Expected calculated score from judgements of ${calculatedScore} to equal score of ${s.scoreData.score}.`;
+	// }
+	// },
 	(s) => {
 		const { MARVELOUS, PERFECT, GREAT, GOOD, MISS } = s.scoreData.judgements;
 


### PR DESCRIPTION
The score validation using judgements is broken due to the absence of the correct hold count if some holds have been missed by the player during the song. This breaks the `stepScore` value and computes a wrong score and invalidates some scores.

Until we have a way to get the actual steps count and holds count for every single chart, this validation function must be disabled.