### PR TITLE
fix: FlareSkill PB update

### DIFF
--- a/server/src/game-implementations/games/ddr.ts
+++ b/server/src/game-implementations/games/ddr.ts
@@ -1,10 +1,4 @@
-import {
-	GoalFmtPercent,
-	GoalFmtScore,
-	GoalOutOfFmtPercent,
-	GoalOutOfFmtScore,
-	GradeGoalFormatter,
-} from "./_common";
+import { GoalFmtScore, GoalOutOfFmtScore, GradeGoalFormatter } from "./_common";
 import db from "../../external/mongo/db";
 import { IsNullish } from "../../utils/misc";
 import { CreatePBMergeFor } from "../utils/pb-merge";
@@ -259,6 +253,16 @@ export const DDR_IMPL: GPTServerImplementation<"ddr:DP" | "ddr:SP"> = {
 		CreatePBMergeFor("largest", "score", "Best Score", (base, score) => {
 			base.scoreData.score = score.scoreData.score;
 			base.scoreData.grade = score.scoreData.grade;
+		}),
+		CreatePBMergeFor("largest", "optional.enumIndexes.flare", "Best Flare", (base, score) => {
+			base.scoreData.optional.flare =
+				score.scoreData.lamp !== "FAILED"
+					? score.scoreData.optional.flare
+					: base.scoreData.optional.flare;
+			base.calculatedData.flareSkill =
+				score.scoreData.lamp !== "FAILED"
+					? score.calculatedData.flareSkill
+					: base.calculatedData.flareSkill;
 		}),
 	],
 	profileCalcs: {

--- a/server/src/lib/score-import/framework/score-importing/derivers.ts
+++ b/server/src/lib/score-import/framework/score-importing/derivers.ts
@@ -77,10 +77,7 @@ export function CreateEnumIndexes<GPT extends GPTString>(gpt: GPT, metrics: any,
 		indexes[key] = index;
 	}
 
-	for (const [key, conf] of [
-		...Object.entries(gptConfig.providedMetrics),
-		...Object.entries(gptConfig.derivedMetrics),
-	]) {
+	for (const [key, conf] of [...Object.entries(gptConfig.optionalMetrics)]) {
 		if (conf.type !== "ENUM") {
 			continue;
 		}
@@ -103,7 +100,7 @@ export function CreateEnumIndexes<GPT extends GPTString>(gpt: GPT, metrics: any,
 			);
 		}
 
-		indexes[key] = index;
+		optionalIndexes[key] = index;
 	}
 
 	return {


### PR DESCRIPTION
Adding a new PB merge function to update flare in PB scores. This will also fix the profile ranking.

Some actions need to be done to update existing data : 

- Recreate `enumIndexes` for `scoreData.optional` in scores, since there was a bug in `derivers.ts` that prevented the creation of those
- Update PB merges with the newly updated `optional.enumIndexes`
- Recompute profile ratings