### PR TITLE
dev: make some bootstrapping steps always run

### DIFF
--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -37,8 +37,8 @@ function mvExampleFiles {
 }
 
 function selfSignHTTPS {
-	if [ -e server/cert/key.pem ] && [ -e server/cert/cert.pem ]; then
-		echo "HTTPS Certificates for local-dev server already exists."
+	if [ -e server/cert/key.pem ] && [ -e server/cert/cert.pem ] && openssl x509 -checkend 0 -noout -in server/cert/cert.pem; then
+		echo "HTTPS Certificates for local-dev server already exists and has not expired."
 		return 0
 	fi
 


### PR DESCRIPTION
Sometimes, due to circumstances, you may have to rebuild the dev container, which means that `node_modules` and installed packages will be lost, but since `BOOTSTRAP_OK` still exists, they won't be reinstalled automatically.

This PR changes the bootstrapping script so that some steps become idempotent and thus we don't need to check for the `BOOTSTRAP_OK` file:
- `mvExampleFiles` uses `cp --update=none` to make sure that the example file won't be copied over if the config file already exists.
- `selfSignHTTPS` checks if the cert files already exists and has not expired before continuing.
- `pnpmInstall`/`installLocalDebs` doesn't do much if the packages have already installed.