### PR TITLE
fix: deal with FP issue in DDR judgments

### DIFF
--- a/server/src/game-implementations/games/ddr.ts
+++ b/server/src/game-implementations/games/ddr.ts
@@ -80,7 +80,7 @@ export const DDR_SCORE_VALIDATORS: Array<ScoreValidator<"ddr:DP" | "ddr:SP">> = 
 					(stepScore - 10) * PERFECT +
 					((stepScore * 3) / 5 - 10) * GREAT +
 					(stepScore / 5 - 10) * GOOD +
-					1e-6) / // Floating point inaccuracy can cause 999959.9999999 which gets incorrectly floored
+					1e-9) / // Floating point inaccuracy can cause 999959.9999999 which gets incorrectly floored
 					10
 			) * 10;
 


### PR DESCRIPTION
Added a value of 1e-9 to the score before it gets floored to resolve judgment errors caused by floating point inaccuracy.

Very reasonable to say no score will ever end in .999999999

Tested on user who was having issues and other scores (~3.8k total) with all judgment errors being fixed.