### PR TITLE
fix(client): sort ongeki p-score by %

### DIFF
--- a/client/src/lib/game-implementations.tsx
+++ b/client/src/lib/game-implementations.tsx
@@ -848,7 +848,9 @@ export const GPT_CLIENT_IMPLEMENTATIONS: GPTClientImplementations = {
 			[
 				"Platinum Score",
 				"P-Score",
-				NumericSOV((x) => x.scoreData.platinumStars * 100000 + x.scoreData.platinumScore),
+				NumericSOV(
+					(x) => x.scoreData.platinumScore / (x as any).__related.chart.data.maxPlatScore
+				),
 			],
 			["Judgements", "Notes", NumericSOV((x) => x.scoreData.judgements.cbreak ?? 0)],
 			[


### PR DESCRIPTION
In my defense, I wasn't aware I had to look for hidden private fields at runtime.