### PR TITLE
feat: add M+ support, seeds up to 2025121000

### DIFF
--- a/db/seeds/charts-museca.json
+++ b/db/seeds/charts-museca.json
@@ -10,7 +10,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b424a871d843",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -23,7 +23,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b424a871d843",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -36,7 +36,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b424a871d843",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -49,7 +49,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b42563153da1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -62,7 +62,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b42563153da1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -75,7 +75,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b42563153da1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -88,7 +88,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4260c99709f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -101,7 +101,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4260c99709f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -114,7 +114,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4260c99709f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -127,7 +127,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b427216a19cb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -140,7 +140,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b427216a19cb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -153,7 +153,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b427216a19cb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -166,7 +166,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b42802376fc6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -179,7 +179,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b42802376fc6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -192,7 +192,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b42802376fc6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -205,7 +205,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4294c048a01",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -218,7 +218,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4294c048a01",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -231,7 +231,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4294c048a01",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -244,7 +244,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b42ada9d9ed7",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -257,7 +257,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b42ada9d9ed7",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -270,7 +270,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b42ada9d9ed7",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -283,7 +283,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b42b41d8a9da",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -296,7 +296,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b42b41d8a9da",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -309,7 +309,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b42b41d8a9da",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -322,7 +322,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b42c5ca82cd6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -335,7 +335,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b42c5ca82cd6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -348,7 +348,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b42c5ca82cd6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -361,7 +361,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b42deee844e7",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -374,7 +374,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b42deee844e7",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -387,7 +387,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b42deee844e7",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -400,7 +400,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b42e91742443",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -413,7 +413,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b42e91742443",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -426,7 +426,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b42e91742443",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -439,7 +439,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b42f6d1ef0bb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -452,7 +452,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b42f6d1ef0bb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -465,7 +465,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b42f6d1ef0bb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -478,7 +478,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b430e6c9c39a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -491,7 +491,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b430e6c9c39a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -504,7 +504,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b430e6c9c39a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -517,7 +517,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4310625169e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -530,7 +530,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4310625169e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -543,7 +543,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4310625169e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -556,7 +556,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b432089e21fd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -569,7 +569,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b432089e21fd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -582,7 +582,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b432089e21fd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -595,7 +595,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b433da522721",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -608,7 +608,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b433da522721",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -621,7 +621,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b433da522721",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -634,7 +634,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4348d400e96",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -647,7 +647,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4348d400e96",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -660,7 +660,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4348d400e96",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -673,7 +673,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b435a966cff4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -686,7 +686,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b435a966cff4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -699,7 +699,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b435a966cff4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -712,7 +712,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4365a06f67c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -725,7 +725,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4365a06f67c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -738,7 +738,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4365a06f67c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -751,7 +751,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b437e0e92ab2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -764,7 +764,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b437e0e92ab2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -777,7 +777,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b437e0e92ab2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -790,7 +790,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b438a6947131",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -803,7 +803,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b438a6947131",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -816,7 +816,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b438a6947131",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -829,7 +829,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b439c7c2ca64",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -842,7 +842,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b439c7c2ca64",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -855,7 +855,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b439c7c2ca64",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -868,7 +868,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b43a3b67fca6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -881,7 +881,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b43a3b67fca6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -894,7 +894,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b43a3b67fca6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -907,7 +907,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b43b1eaae93e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -920,7 +920,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b43b1eaae93e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -933,7 +933,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b43b1eaae93e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -946,7 +946,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b43c3a02ef94",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -959,7 +959,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b43c3a02ef94",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -972,7 +972,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b43c3a02ef94",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -985,7 +985,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b43df9a3e791",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -998,7 +998,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b43df9a3e791",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1011,7 +1011,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b43df9a3e791",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1024,7 +1024,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b43e462d06f8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1037,7 +1037,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b43e462d06f8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1050,7 +1050,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b43e462d06f8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1063,7 +1063,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b43f3e8dcf3c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1076,7 +1076,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b43f3e8dcf3c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1089,7 +1089,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b43f3e8dcf3c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1102,7 +1102,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4408cf2f105",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1115,7 +1115,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4408cf2f105",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1128,7 +1128,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4408cf2f105",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1141,7 +1141,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4426e5a2f8d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1154,7 +1154,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4426e5a2f8d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1167,7 +1167,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4426e5a2f8d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1180,7 +1180,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b443e7ccf644",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1193,7 +1193,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b443e7ccf644",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1206,7 +1206,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b443e7ccf644",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1219,7 +1219,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b44440c9f6eb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1232,7 +1232,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b44440c9f6eb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1245,7 +1245,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b44440c9f6eb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1258,7 +1258,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4453c98e51d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1271,7 +1271,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4453c98e51d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1284,7 +1284,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4453c98e51d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1297,7 +1297,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b44658211805",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1310,7 +1310,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b44658211805",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1323,7 +1323,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b44658211805",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1336,7 +1336,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b448ca11f6d5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1349,7 +1349,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b448ca11f6d5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1362,7 +1362,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b448ca11f6d5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1375,7 +1375,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b4491f73dd42",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1388,7 +1388,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4491f73dd42",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1401,7 +1401,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4491f73dd42",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1414,7 +1414,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b44ecf751468",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1427,7 +1427,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b44ecf751468",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1440,7 +1440,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b44ecf751468",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1453,7 +1453,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b450d503f78d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1466,7 +1466,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b450d503f78d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1479,7 +1479,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b450d503f78d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1492,7 +1492,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b45165912643",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1505,7 +1505,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b45165912643",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1518,7 +1518,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b45165912643",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1531,7 +1531,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b452778ae4ab",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1544,7 +1544,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b452778ae4ab",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1557,7 +1557,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b452778ae4ab",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1570,7 +1570,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b453b9b68803",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1583,7 +1583,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b453b9b68803",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1596,7 +1596,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b453b9b68803",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1609,7 +1609,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b45490c2341a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1622,7 +1622,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b45490c2341a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1635,7 +1635,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b45490c2341a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1648,7 +1648,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b456e0415752",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1661,7 +1661,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b456e0415752",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1674,7 +1674,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b456e0415752",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1687,7 +1687,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b457b6ee159e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1700,7 +1700,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b457b6ee159e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1713,7 +1713,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b457b6ee159e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1726,7 +1726,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b45884e26e99",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1739,7 +1739,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b45884e26e99",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1752,7 +1752,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b45884e26e99",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1765,7 +1765,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b45914cf2311",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1778,7 +1778,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b45914cf2311",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1791,7 +1791,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b45914cf2311",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1804,7 +1804,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b45a2ad510b4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1817,7 +1817,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b45a2ad510b4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1830,7 +1830,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b45a2ad510b4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1843,7 +1843,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b45bb5a60b1b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1856,7 +1856,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b45bb5a60b1b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1869,7 +1869,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b45bb5a60b1b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1882,7 +1882,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b45cd9727ba2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1895,7 +1895,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b45cd9727ba2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1908,7 +1908,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b45cd9727ba2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1921,7 +1921,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b45d7632a1fb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1934,7 +1934,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b45d7632a1fb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1947,7 +1947,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b45d7632a1fb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1960,7 +1960,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b45e470ebe98",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1973,7 +1973,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b45e470ebe98",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1986,7 +1986,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b45e470ebe98",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -1999,7 +1999,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b45f3df0d51b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2012,7 +2012,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b45f3df0d51b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2025,7 +2025,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b45f3df0d51b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2038,7 +2038,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b460ab3b63da",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2051,7 +2051,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b460ab3b63da",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2064,7 +2064,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b460ab3b63da",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2077,7 +2077,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b461cefd23d4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2090,7 +2090,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b461cefd23d4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2103,7 +2103,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b461cefd23d4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2116,7 +2116,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b46257f6db19",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2129,7 +2129,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b46257f6db19",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2142,7 +2142,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b46257f6db19",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2155,7 +2155,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b463a7f02850",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2168,7 +2168,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b463a7f02850",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2181,7 +2181,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b463a7f02850",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2194,7 +2194,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4647d3895ee",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2207,7 +2207,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4647d3895ee",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2220,7 +2220,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4647d3895ee",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2233,7 +2233,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b465851a3266",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2246,7 +2246,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b465851a3266",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2259,7 +2259,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b465851a3266",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2272,7 +2272,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b466dc9010de",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2285,7 +2285,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b466dc9010de",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2298,7 +2298,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b466dc9010de",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2311,7 +2311,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b467868467ac",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2324,7 +2324,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b467868467ac",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2337,7 +2337,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b467868467ac",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2350,7 +2350,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b468bec14c18",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2363,7 +2363,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b468bec14c18",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2376,7 +2376,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b468bec14c18",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2389,7 +2389,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4697a16fc0b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2402,7 +2402,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4697a16fc0b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2415,7 +2415,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4697a16fc0b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2428,7 +2428,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b46a20329db9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2441,7 +2441,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b46a20329db9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2454,7 +2454,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b46a20329db9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2467,7 +2467,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b46b99b43a84",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2480,7 +2480,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b46b99b43a84",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2493,7 +2493,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b46b99b43a84",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2506,7 +2506,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b46c418cb23c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2519,7 +2519,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b46c418cb23c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2532,7 +2532,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b46c418cb23c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2545,7 +2545,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b46de96c7e37",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2558,7 +2558,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b46de96c7e37",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2571,7 +2571,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b46de96c7e37",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2584,7 +2584,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b46ee6e99d48",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2597,7 +2597,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b46ee6e99d48",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2610,7 +2610,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b46ee6e99d48",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2623,7 +2623,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b46fb1becd20",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2636,7 +2636,7 @@
 		"level": "16",
 		"levelNum": 16,
 		"songID": "S19d35e0b46fb1becd20",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2649,7 +2649,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b46fb1becd20",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2662,7 +2662,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b470de6e2ba6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2675,7 +2675,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b470de6e2ba6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2688,7 +2688,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b470de6e2ba6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2701,7 +2701,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b47197226a2c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2714,7 +2714,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b47197226a2c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2727,7 +2727,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b47197226a2c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2740,7 +2740,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b47286bbe32a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2753,7 +2753,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b47286bbe32a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2766,7 +2766,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b47286bbe32a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2779,7 +2779,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b473f1e4faf8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2792,7 +2792,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b473f1e4faf8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2805,7 +2805,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b473f1e4faf8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2818,7 +2818,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4741af6c4c0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2831,7 +2831,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4741af6c4c0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2844,7 +2844,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4741af6c4c0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2857,7 +2857,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b47507bd7819",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2870,7 +2870,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b47507bd7819",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2883,7 +2883,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b47507bd7819",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2896,7 +2896,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b476b9b706de",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2909,7 +2909,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b476b9b706de",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2922,7 +2922,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b476b9b706de",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2935,7 +2935,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b47723a31283",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2948,7 +2948,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b47723a31283",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2961,7 +2961,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b47723a31283",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2974,7 +2974,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b478ec2c4846",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -2987,7 +2987,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b478ec2c4846",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3000,7 +3000,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b478ec2c4846",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3013,7 +3013,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4790ec7fb8b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3026,7 +3026,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4790ec7fb8b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3039,7 +3039,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4790ec7fb8b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3052,7 +3052,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b47a287e7692",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3065,7 +3065,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b47a287e7692",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3078,7 +3078,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b47a287e7692",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3091,7 +3091,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b47ba23221e9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3104,7 +3104,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b47ba23221e9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3117,7 +3117,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b47ba23221e9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3130,7 +3130,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b47ce097c39f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3143,7 +3143,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b47ce097c39f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3156,7 +3156,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b47ce097c39f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3169,7 +3169,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b47da503c4fb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3182,7 +3182,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b47da503c4fb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3195,7 +3195,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b47da503c4fb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3208,7 +3208,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b47ede77eeb2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3221,7 +3221,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b47ede77eeb2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3234,7 +3234,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b47ede77eeb2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3247,7 +3247,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b47f5beefa69",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3260,7 +3260,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b47f5beefa69",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3273,7 +3273,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b47f5beefa69",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3286,7 +3286,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b480a8912fcf",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3299,7 +3299,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b480a8912fcf",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3312,7 +3312,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b480a8912fcf",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3325,7 +3325,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b481716e2692",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3338,7 +3338,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b481716e2692",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3351,7 +3351,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b481716e2692",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3364,7 +3364,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b48292b0c5d5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3377,7 +3377,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b48292b0c5d5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3390,7 +3390,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b48292b0c5d5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3403,7 +3403,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b48396ffdbb0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3416,7 +3416,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b48396ffdbb0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3429,7 +3429,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b48396ffdbb0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3442,7 +3442,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b48490a37761",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3455,7 +3455,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b48490a37761",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3468,7 +3468,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b48490a37761",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3481,7 +3481,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4852266cb52",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3494,7 +3494,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4852266cb52",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3507,7 +3507,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4852266cb52",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3520,7 +3520,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b486f3c4c317",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3533,7 +3533,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b486f3c4c317",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3546,7 +3546,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b486f3c4c317",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3559,7 +3559,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b488cde6f260",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3572,7 +3572,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b488cde6f260",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3585,7 +3585,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b488cde6f260",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3598,7 +3598,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b48a215882c2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3611,7 +3611,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b48a215882c2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3624,7 +3624,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b48a215882c2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3637,7 +3637,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b48bc9b3561d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3650,7 +3650,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b48bc9b3561d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3663,7 +3663,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b48bc9b3561d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3676,7 +3676,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b48dd60ad618",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3689,7 +3689,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b48dd60ad618",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3702,7 +3702,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b48dd60ad618",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3715,7 +3715,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b48eed08c590",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3728,7 +3728,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b48eed08c590",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3741,7 +3741,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b48eed08c590",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3754,7 +3754,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b48fab7c3dfa",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3767,7 +3767,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b48fab7c3dfa",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3780,7 +3780,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b48fab7c3dfa",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3793,7 +3793,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4904c557874",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3806,7 +3806,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4904c557874",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3819,7 +3819,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4904c557874",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3832,7 +3832,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4912dffb3b9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3845,7 +3845,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4912dffb3b9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3858,7 +3858,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4912dffb3b9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3871,7 +3871,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b492bcaa581a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3884,7 +3884,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b492bcaa581a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3897,7 +3897,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b492bcaa581a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3910,7 +3910,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b49326eb55c9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3923,7 +3923,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b49326eb55c9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3936,7 +3936,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b49326eb55c9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3949,7 +3949,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4945e77b474",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3962,7 +3962,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4945e77b474",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3975,7 +3975,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4945e77b474",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -3988,7 +3988,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b496b861042a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4001,7 +4001,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b496b861042a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4014,7 +4014,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b496b861042a",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4027,7 +4027,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b4976ae52545",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4040,7 +4040,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4976ae52545",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4053,7 +4053,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4976ae52545",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4066,7 +4066,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b498b6d18bf5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4079,7 +4079,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b498b6d18bf5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4092,7 +4092,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b498b6d18bf5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4105,7 +4105,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b499cc493584",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4118,7 +4118,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b499cc493584",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4131,7 +4131,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b499cc493584",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4144,7 +4144,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b49ae4bf23cc",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4157,7 +4157,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b49ae4bf23cc",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4170,7 +4170,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b49ae4bf23cc",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4183,7 +4183,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4a1c0a1b781",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4196,7 +4196,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4a1c0a1b781",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4209,7 +4209,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4a1c0a1b781",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4222,7 +4222,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4a2a74a6e94",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4235,7 +4235,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4a2a74a6e94",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4248,7 +4248,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4a2a74a6e94",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4261,7 +4261,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4a391738c8e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4274,7 +4274,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4a391738c8e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4287,7 +4287,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4a391738c8e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4300,7 +4300,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4a4fda03216",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4313,7 +4313,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4a4fda03216",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4326,7 +4326,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4a4fda03216",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4339,7 +4339,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4a59e0c74e9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4352,7 +4352,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4a59e0c74e9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4365,7 +4365,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4a59e0c74e9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4378,7 +4378,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4a67db4b0c9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4391,7 +4391,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4a67db4b0c9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4404,7 +4404,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4a67db4b0c9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4417,7 +4417,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4a77b8dd4cd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4430,7 +4430,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4a77b8dd4cd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4443,7 +4443,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4a77b8dd4cd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4456,7 +4456,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4a815a44ae0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4469,7 +4469,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4a815a44ae0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4482,7 +4482,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4a815a44ae0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4495,7 +4495,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4a98cc00922",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4508,7 +4508,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4a98cc00922",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4521,7 +4521,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4a98cc00922",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4534,7 +4534,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4aaa6f1ee7f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4547,7 +4547,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4aaa6f1ee7f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4560,7 +4560,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4aaa6f1ee7f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4573,7 +4573,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4ab8cffa954",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4586,7 +4586,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4ab8cffa954",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4599,7 +4599,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4ab8cffa954",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4612,7 +4612,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4ac68f1c29f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4625,7 +4625,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4ac68f1c29f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4638,7 +4638,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4ac68f1c29f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4651,7 +4651,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4ad2c3f9d37",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4664,7 +4664,7 @@
 		"level": "16",
 		"levelNum": 16,
 		"songID": "S19d35e0b4ad2c3f9d37",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4677,7 +4677,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4ad2c3f9d37",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4690,7 +4690,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4ae1e8cc03b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4703,7 +4703,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4ae1e8cc03b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4716,7 +4716,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4ae1e8cc03b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4729,7 +4729,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4af9da40582",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4742,7 +4742,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4af9da40582",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4755,7 +4755,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4af9da40582",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4768,7 +4768,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4b000fbeff0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4781,7 +4781,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4b000fbeff0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4794,7 +4794,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4b000fbeff0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4807,7 +4807,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4b16957f82e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4820,7 +4820,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4b16957f82e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4833,7 +4833,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4b16957f82e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4846,7 +4846,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4b27027962e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4859,7 +4859,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4b27027962e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4872,7 +4872,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4b27027962e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4885,7 +4885,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4b3b404e72c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4898,7 +4898,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4b3b404e72c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4911,7 +4911,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4b3b404e72c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4924,7 +4924,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4b47ca30370",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4937,7 +4937,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4b47ca30370",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4950,7 +4950,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4b47ca30370",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4963,7 +4963,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4b5b47e5ce1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4976,7 +4976,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4b5b47e5ce1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -4989,7 +4989,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4b5b47e5ce1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5002,7 +5002,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4b638fd46df",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5015,7 +5015,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4b638fd46df",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5028,7 +5028,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4b638fd46df",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5041,7 +5041,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4b79b21e249",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5054,7 +5054,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4b79b21e249",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5067,7 +5067,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4b79b21e249",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5080,7 +5080,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4b8cd747b94",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5093,7 +5093,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4b8cd747b94",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5106,7 +5106,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4b8cd747b94",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5119,7 +5119,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4b942b6dde2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5132,7 +5132,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4b942b6dde2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5145,7 +5145,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4b942b6dde2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5158,7 +5158,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4bab8666368",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5171,7 +5171,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4bab8666368",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5184,7 +5184,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4bab8666368",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5197,7 +5197,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4bbff1b917d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5210,7 +5210,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4bbff1b917d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5223,7 +5223,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4bbff1b917d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5236,7 +5236,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4bc2c5944b3",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5249,7 +5249,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4bc2c5944b3",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5262,7 +5262,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4bc2c5944b3",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5275,7 +5275,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4bdc55a2d14",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5288,7 +5288,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4bdc55a2d14",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5301,7 +5301,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4bdc55a2d14",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5314,7 +5314,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4bec5c78af1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5327,7 +5327,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4bec5c78af1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5340,7 +5340,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4bec5c78af1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5353,7 +5353,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4bf31d86426",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5366,7 +5366,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4bf31d86426",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5379,7 +5379,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4bf31d86426",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5392,7 +5392,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4c02b1afb22",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5405,7 +5405,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4c02b1afb22",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5418,7 +5418,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4c02b1afb22",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5431,7 +5431,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4c2dc354559",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5444,7 +5444,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4c2dc354559",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5457,7 +5457,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4c2dc354559",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5470,7 +5470,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4c386fb9c5e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5483,7 +5483,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4c386fb9c5e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5496,7 +5496,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4c386fb9c5e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5509,7 +5509,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4c432cfead3",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5522,7 +5522,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4c432cfead3",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5535,7 +5535,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4c432cfead3",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5548,7 +5548,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4c59a750bc1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5561,7 +5561,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4c59a750bc1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5574,7 +5574,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4c59a750bc1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5587,7 +5587,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4c68c506a1d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5600,7 +5600,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4c68c506a1d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5613,7 +5613,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4c68c506a1d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5626,7 +5626,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4c7a4f454e4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5639,7 +5639,7 @@
 		"level": "16",
 		"levelNum": 16,
 		"songID": "S19d35e0b4c7a4f454e4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5652,7 +5652,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4c7a4f454e4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5665,7 +5665,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4c8affaa23d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5678,7 +5678,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4c8affaa23d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5691,7 +5691,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4c8affaa23d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5704,7 +5704,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4c9f302a75f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5717,7 +5717,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4c9f302a75f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5730,7 +5730,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4c9f302a75f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5743,7 +5743,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4cab505a10e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5756,7 +5756,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4cab505a10e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5769,7 +5769,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4cab505a10e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5782,7 +5782,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4cb8853e92d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5795,7 +5795,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4cb8853e92d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5808,7 +5808,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4cb8853e92d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5821,7 +5821,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4cc0b2e432c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5834,7 +5834,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4cc0b2e432c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5847,7 +5847,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4cc0b2e432c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5860,7 +5860,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4cdb15676bd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5873,7 +5873,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4cdb15676bd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5886,7 +5886,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4cdb15676bd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5899,7 +5899,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4ce42939fbd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5912,7 +5912,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4ce42939fbd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5925,7 +5925,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4ce42939fbd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5938,7 +5938,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4d0f33e4f4d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5951,7 +5951,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4d0f33e4f4d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5964,7 +5964,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4d0f33e4f4d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5977,7 +5977,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4d109282528",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -5990,7 +5990,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4d109282528",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6003,7 +6003,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4d109282528",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6016,7 +6016,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b4d25deec550",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6029,7 +6029,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4d25deec550",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6042,7 +6042,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4d25deec550",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6055,7 +6055,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4d347646ee9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6068,7 +6068,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4d347646ee9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6081,7 +6081,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4d347646ee9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6094,7 +6094,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4d4588ce9a8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6107,7 +6107,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4d4588ce9a8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6120,7 +6120,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4d4588ce9a8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6133,7 +6133,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4d522fec168",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6146,7 +6146,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4d522fec168",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6159,7 +6159,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4d522fec168",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6172,7 +6172,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b4d6b388f054",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6185,7 +6185,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4d6b388f054",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6198,7 +6198,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4d6b388f054",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6211,7 +6211,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4d78d4251a6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6224,7 +6224,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4d78d4251a6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6237,7 +6237,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4d78d4251a6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6250,7 +6250,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4d8b3415226",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6263,7 +6263,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4d8b3415226",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6276,7 +6276,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4d8b3415226",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6289,7 +6289,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4d9abfe5509",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6302,7 +6302,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4d9abfe5509",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6315,7 +6315,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4d9abfe5509",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6328,7 +6328,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4daffd100e2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6341,7 +6341,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4daffd100e2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6354,7 +6354,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4daffd100e2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6367,7 +6367,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4dbf2fe4c84",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6380,7 +6380,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4dbf2fe4c84",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6393,7 +6393,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4dbf2fe4c84",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6406,7 +6406,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4dc77413607",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6419,7 +6419,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4dc77413607",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6432,7 +6432,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4dc77413607",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6445,7 +6445,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4dda126b6a2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6458,7 +6458,7 @@
 		"level": "16",
 		"levelNum": 16,
 		"songID": "S19d35e0b4dda126b6a2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6471,7 +6471,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4dda126b6a2",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6484,7 +6484,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4de2503c4e5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6497,7 +6497,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4de2503c4e5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6510,7 +6510,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4de2503c4e5",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6523,7 +6523,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4dfc75d136c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6536,7 +6536,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4dfc75d136c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6549,7 +6549,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4dfc75d136c",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6562,7 +6562,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4e0e67e0db3",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6575,7 +6575,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4e0e67e0db3",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6588,7 +6588,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4e0e67e0db3",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6601,7 +6601,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4e19cd0173f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6614,7 +6614,7 @@
 		"level": "16",
 		"levelNum": 16,
 		"songID": "S19d35e0b4e19cd0173f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6627,7 +6627,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4e19cd0173f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6640,7 +6640,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4e25fecb8fe",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6653,7 +6653,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4e25fecb8fe",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6666,7 +6666,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4e25fecb8fe",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6679,7 +6679,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4e3589cd4cc",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6692,7 +6692,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4e3589cd4cc",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6705,7 +6705,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4e3589cd4cc",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6718,7 +6718,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4e4390e3d00",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6731,7 +6731,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4e4390e3d00",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6744,7 +6744,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4e4390e3d00",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6757,7 +6757,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4e5aa657312",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6770,7 +6770,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4e5aa657312",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6783,7 +6783,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4e5aa657312",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6796,7 +6796,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4e6934193a9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6809,7 +6809,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4e6934193a9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6822,7 +6822,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4e6934193a9",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6835,7 +6835,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4e7d294e4d7",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6848,7 +6848,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4e7d294e4d7",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6861,7 +6861,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4e7d294e4d7",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6874,7 +6874,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4e9c44f8a01",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6887,7 +6887,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4e9c44f8a01",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6900,7 +6900,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4e9c44f8a01",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6913,7 +6913,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b4eaae228e2e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6926,7 +6926,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4eaae228e2e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6939,7 +6939,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4eaae228e2e",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6952,7 +6952,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4ebd3f2b50d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6965,7 +6965,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4ebd3f2b50d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6978,7 +6978,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4ebd3f2b50d",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -6991,7 +6991,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4edb85a9ee8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7004,7 +7004,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4edb85a9ee8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7017,7 +7017,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4edb85a9ee8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7030,7 +7030,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b4eeba058b01",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7043,7 +7043,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4eeba058b01",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7056,7 +7056,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b4eeba058b01",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7069,7 +7069,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4ef9cceb5de",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7082,7 +7082,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4ef9cceb5de",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7095,7 +7095,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4ef9cceb5de",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7108,7 +7108,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4f0fa6df0d8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7121,7 +7121,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4f0fa6df0d8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7134,7 +7134,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4f0fa6df0d8",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7147,7 +7147,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4f197879438",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7160,7 +7160,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4f197879438",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7173,7 +7173,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4f197879438",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7186,7 +7186,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b4f2fd7a2f33",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7199,7 +7199,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4f2fd7a2f33",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7212,7 +7212,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4f2fd7a2f33",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7225,7 +7225,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4f3090c2f0b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7238,7 +7238,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4f3090c2f0b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7251,7 +7251,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4f3090c2f0b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7264,7 +7264,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4f4fbecdd83",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7277,7 +7277,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4f4fbecdd83",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7290,7 +7290,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b4f4fbecdd83",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7303,7 +7303,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4f57d54e05b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7316,7 +7316,7 @@
 		"level": "16",
 		"levelNum": 16,
 		"songID": "S19d35e0b4f57d54e05b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7329,7 +7329,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4f57d54e05b",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7342,7 +7342,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4f64618d8c4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7355,7 +7355,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4f64618d8c4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7368,7 +7368,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4f64618d8c4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7381,7 +7381,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4f7d6443ea0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7394,7 +7394,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4f7d6443ea0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7407,7 +7407,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4f7d6443ea0",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7420,7 +7420,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4f8792bf46f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7433,7 +7433,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4f8792bf46f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7446,7 +7446,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4f8792bf46f",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7459,7 +7459,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4f9035eeb20",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7472,7 +7472,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4f9035eeb20",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7485,7 +7485,7 @@
 		"level": "7",
 		"levelNum": 7,
 		"songID": "S19d35e0b4f9035eeb20",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7498,7 +7498,7 @@
 		"level": "1",
 		"levelNum": 1,
 		"songID": "S19d35e0b4fa33705bfb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7511,7 +7511,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b4fa33705bfb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7524,7 +7524,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4fa33705bfb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7537,7 +7537,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4fb0b7a8639",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7550,7 +7550,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4fb0b7a8639",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7563,7 +7563,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4fb0b7a8639",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7576,7 +7576,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4fcfc500fd4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7589,7 +7589,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4fcfc500fd4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7602,7 +7602,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4fcfc500fd4",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7615,7 +7615,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b4fd2f3aef55",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7628,7 +7628,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4fd2f3aef55",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7641,7 +7641,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4fd2f3aef55",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7654,7 +7654,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4fe3abaac41",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7667,7 +7667,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b4fe3abaac41",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7680,7 +7680,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b4fe3abaac41",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7693,7 +7693,7 @@
 		"level": "4",
 		"levelNum": 4,
 		"songID": "S19d35e0b4ff16aac474",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7706,7 +7706,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b4ff16aac474",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7719,7 +7719,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b4ff16aac474",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7732,7 +7732,7 @@
 		"level": "2",
 		"levelNum": 2,
 		"songID": "S19d35e0b500f0d94c53",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7745,7 +7745,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b500f0d94c53",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7758,7 +7758,7 @@
 		"level": "8",
 		"levelNum": 8,
 		"songID": "S19d35e0b500f0d94c53",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7771,7 +7771,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b50107bdef69",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7784,7 +7784,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b50107bdef69",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7797,7 +7797,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b50107bdef69",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7810,7 +7810,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b502872e4dc1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7823,7 +7823,7 @@
 		"level": "14",
 		"levelNum": 14,
 		"songID": "S19d35e0b502872e4dc1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7836,7 +7836,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b502872e4dc1",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7849,7 +7849,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b5034f3776b6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7862,7 +7862,7 @@
 		"level": "16",
 		"levelNum": 16,
 		"songID": "S19d35e0b5034f3776b6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7875,7 +7875,7 @@
 		"level": "10",
 		"levelNum": 10,
 		"songID": "S19d35e0b5034f3776b6",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7888,7 +7888,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b505d9ba12cd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7901,7 +7901,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b505d9ba12cd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7914,7 +7914,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b505d9ba12cd",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7927,7 +7927,7 @@
 		"level": "6",
 		"levelNum": 6,
 		"songID": "S19d35e0b506c6a58ca7",
-		"versions": ["1.5-b"]
+		"versions": ["1.5-b", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7940,7 +7940,7 @@
 		"level": "15",
 		"levelNum": 15,
 		"songID": "S19d35e0b506c6a58ca7",
-		"versions": ["1.5-b"]
+		"versions": ["1.5-b", "1.5-b", "m+"]
 	},
 	{
 		"data": {
@@ -7953,6 +7953,6129 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b506c6a58ca7",
-		"versions": ["1.5-b"]
+		"versions": ["1.5-b", "1.5-b", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 41
+		},
+		"difficulty": "Green",
+		"id": "C19e3de3b031802ee11e",
+		"isPrimary": true,
+		"legacyChartID": "7d0b48bf9e327bb8c2dccc4121ab7a2dbaa47df5",
+		"level": "2",
+		"levelNum": 2,
+		"songID": "S19e3dbc52e8666a9202",
+		"versions": ["1.5", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 41
+		},
+		"difficulty": "Red",
+		"id": "C19e3de3b031cf83975a",
+		"isPrimary": true,
+		"legacyChartID": "517c4846eacd65029bae133ed5483602d0b3863b",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3dbc52e8666a9202",
+		"versions": ["1.5", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 41
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de3b031ba1e72b4",
+		"isPrimary": true,
+		"legacyChartID": "8abd766ab1291cf2e009bc0118db70d61d7b2200",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3dbc52e8666a9202",
+		"versions": ["1.5", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 42
+		},
+		"difficulty": "Green",
+		"id": "C19e3de3b0318f908fbb",
+		"isPrimary": true,
+		"legacyChartID": "98b15e99055b430a1164f65845e8e46960bbe28c",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3dbc52e8acfb31ce",
+		"versions": ["1.5", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 42
+		},
+		"difficulty": "Red",
+		"id": "C19e3de3b0312ff0bf85",
+		"isPrimary": true,
+		"legacyChartID": "0e8bfd745e789a0743b5231f46d9ea488cdbecf6",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3dbc52e8acfb31ce",
+		"versions": ["1.5", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 42
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de3b031ebe4b24f",
+		"isPrimary": true,
+		"legacyChartID": "a6984ac2655e307d970c013c0298ecf86b358940",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3dbc52e8acfb31ce",
+		"versions": ["1.5", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 171
+		},
+		"difficulty": "Green",
+		"id": "C19e3de3b033a999b1a7",
+		"isPrimary": true,
+		"legacyChartID": "35aaa7fe08a9ae1e448fb980a7aba6cc518aec20",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3dbc52e8b0cef53e",
+		"versions": ["1.5", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 171
+		},
+		"difficulty": "Red",
+		"id": "C19e3de3b0334ec3d27e",
+		"isPrimary": true,
+		"legacyChartID": "1a9a721477e95528ee8c39e90bf2cda205ca647e",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3dbc52e8b0cef53e",
+		"versions": ["1.5", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 171
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de3b03384444886",
+		"isPrimary": true,
+		"legacyChartID": "0c7bde386f14f7d61e6ef207678861a1c3abf877",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3dbc52e8b0cef53e",
+		"versions": ["1.5", "m+"]
+	},
+	{
+		"data": {
+			"inGameID": 227
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b552dc7718bd",
+		"isPrimary": true,
+		"legacyChartID": "d3d2c62b4d163a9a25a1d521903a35b571bb979b",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b552ae207f8b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 227
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5523965488a",
+		"isPrimary": true,
+		"legacyChartID": "d51be7f70dd55c11efa1bd04d2bc7901ac04bbd2",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b552ae207f8b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 227
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b552a652ddc7",
+		"isPrimary": true,
+		"legacyChartID": "cc6832cfbdb2b98274efa4a2e7b3813f89aab618",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b552ae207f8b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 229
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55234a36150",
+		"isPrimary": true,
+		"legacyChartID": "0407fd3ec873af873d522906f92c26a5c7beef3b",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b552d3e81145",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 229
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b552b82871ab",
+		"isPrimary": true,
+		"legacyChartID": "7a6fc3a8270364632a83164dbbebd6965f77d62b",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b552d3e81145",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 229
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b552edca0b17",
+		"isPrimary": true,
+		"legacyChartID": "433e7332129dfa71137bdef3d55d96e7eb6c57e6",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b552d3e81145",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 228
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5522b424a52",
+		"isPrimary": true,
+		"legacyChartID": "da2f83e8a5f8eb8c0e83cbd523b1e53cf37b0e51",
+		"level": "2",
+		"levelNum": 2,
+		"songID": "S19e3de7b552f857441b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 228
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b552207ba56d",
+		"isPrimary": true,
+		"legacyChartID": "cff32354b52d99b065de6371fd95d0fce0f3849f",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b552f857441b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 228
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55244cc04a8",
+		"isPrimary": true,
+		"legacyChartID": "95d0749c0afe96dac661711dc11d616595d1473b",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b552f857441b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 241
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b553658a1f52",
+		"isPrimary": true,
+		"legacyChartID": "5578ac767679cd74fd69613782f99060410fb04d",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b55313c6ba22",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 241
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553b15d7f29",
+		"isPrimary": true,
+		"legacyChartID": "aab855bba2b929d159ca121e663f4ef4098cdd00",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55313c6ba22",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 241
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5533bb7e4ce",
+		"isPrimary": true,
+		"legacyChartID": "49fffb5a714c89528d817cbc4386bf21021dc122",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b55313c6ba22",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 233
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b553e1d79ec0",
+		"isPrimary": true,
+		"legacyChartID": "4032ae92ec872fc6e8615e05dcbacd9255c9a814",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b5531942fab4",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 233
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5531cabd739",
+		"isPrimary": true,
+		"legacyChartID": "fd0565971bb1c82f0d2efb812f52853514a3e2e4",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5531942fab4",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 233
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55377659a3e",
+		"isPrimary": true,
+		"legacyChartID": "0517dd831b0f9eea32154fb6e761d85727b04a35",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b5531942fab4",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 242
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55308101a5c",
+		"isPrimary": true,
+		"legacyChartID": "487bc108672c4d97c6763d71335ab06221c101fb",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5531d6e4fd6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 242
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5535ad754f2",
+		"isPrimary": true,
+		"legacyChartID": "dda892ca45b5a6fab6376b5208ae005c5a5928bb",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b5531d6e4fd6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 242
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5534e76933f",
+		"isPrimary": true,
+		"legacyChartID": "ce941d484bd8bc7049e8e858dc1f09e619fdbf2c",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5531d6e4fd6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 246
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55333c425aa",
+		"isPrimary": true,
+		"legacyChartID": "d48ed14e20cbcd6acaf4aa030645def5ae87abf2",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b553282fbbb4",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 246
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5537bba121c",
+		"isPrimary": true,
+		"legacyChartID": "943179874c0cd856bc33a558219e3550064d48d8",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b553282fbbb4",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 246
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5539126d34f",
+		"isPrimary": true,
+		"legacyChartID": "695379ae968171669caac651545366673cd677dc",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b553282fbbb4",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 249
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5531b6a1eb5",
+		"isPrimary": true,
+		"legacyChartID": "1721ded7e7b78da56f896ccf2d8a0ab97a78b8ba",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5532a3d6a59",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 249
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553e764d400",
+		"isPrimary": true,
+		"legacyChartID": "0f7c8ee6f8bcc1d0fd4256dae26f3e73881e2d76",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b5532a3d6a59",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 249
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b553f674b0db",
+		"isPrimary": true,
+		"legacyChartID": "ad6f93949108a0d20cb1c6770afe291f3a32dadd",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5532a3d6a59",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 240
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5536a8b3431",
+		"isPrimary": true,
+		"legacyChartID": "47b557ae07eae7cf894b7a19b653bc23219753e0",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b553341da503",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 240
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55344d53ac4",
+		"isPrimary": true,
+		"legacyChartID": "a4a786cafee8beccd648d35e9d298f2ce84acc50",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b553341da503",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 240
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5537232aca3",
+		"isPrimary": true,
+		"legacyChartID": "eb79de3c484efd342e5d3ef3bec96c79b3311075",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b553341da503",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 237
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b553cd00a89a",
+		"isPrimary": true,
+		"legacyChartID": "86bef51fba2fb7f7263876d0d90f249e8d716b8b",
+		"level": "2",
+		"levelNum": 2,
+		"songID": "S19e3de7b5533953052c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 237
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553b25a812a",
+		"isPrimary": true,
+		"legacyChartID": "177238fd7ffc36a285029ba1ed2315f2181541df",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5533953052c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 237
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b553d1f856d5",
+		"isPrimary": true,
+		"legacyChartID": "dffea1230d0bf985568924b4eb55054825134c56",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5533953052c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 245
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5538e519b06",
+		"isPrimary": true,
+		"legacyChartID": "55ba807335e164c047bee13c3c97f4c91fc7f1e9",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b5533dfeeee2",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 245
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553fbc48c57",
+		"isPrimary": true,
+		"legacyChartID": "c66e71666bda39e3718f2c4f69c0ffca87a86a50",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5533dfeeee2",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 245
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5534e643050",
+		"isPrimary": true,
+		"legacyChartID": "d50baa2a1e5de67deb904aad90cb0ff2f358c1c5",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b5533dfeeee2",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 231
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5531e6dffc8",
+		"isPrimary": true,
+		"legacyChartID": "b3c7b45414e61b54af851618a82c04f514756126",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b55340651487",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 231
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5538c07be66",
+		"isPrimary": true,
+		"legacyChartID": "c0cc2b28836d0170bbe0d5e6a0500d0154ca81e7",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55340651487",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 231
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b553e417a9f6",
+		"isPrimary": true,
+		"legacyChartID": "c52b9f0ed728eb9d373e77d05ee5a61a1bd2e7fc",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b55340651487",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 238
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5530d4419a5",
+		"isPrimary": true,
+		"legacyChartID": "063d8bbe6126704d9125e639af701152fd3f50a3",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b553465dd675",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 238
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55396283640",
+		"isPrimary": true,
+		"legacyChartID": "5273e7df5979efb14bcde3476426e87f95e4d33a",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b553465dd675",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 238
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5532a1eb1df",
+		"isPrimary": true,
+		"legacyChartID": "351376ce078de625109997e23bb9c2d9e6da5ea9",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b553465dd675",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 247
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55385dadee9",
+		"isPrimary": true,
+		"legacyChartID": "35edefdb08371a0665ca89794db3659074a87008",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5534c452547",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 247
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55343e5d57e",
+		"isPrimary": true,
+		"legacyChartID": "76804509939ce0a9839b11c3bf06023fc22ddafd",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5534c452547",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 247
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b553c931cadc",
+		"isPrimary": true,
+		"legacyChartID": "6fe712cca948aae768ce333966dd0208d6cc495b",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b5534c452547",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 250
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b553ceb3fea4",
+		"isPrimary": true,
+		"legacyChartID": "38793ee21179174051096e5a314916f0c1b03a80",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5536b62e0f1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 250
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55461f919b1",
+		"isPrimary": true,
+		"legacyChartID": "e92e40a76395f97d50752ade843873150e797e35",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b5536b62e0f1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 250
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55447230206",
+		"isPrimary": true,
+		"legacyChartID": "35ad55d923b32da72128b8b9dd1bdce3b2b4bffc",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5536b62e0f1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 234
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b553b7af044a",
+		"isPrimary": true,
+		"legacyChartID": "8210b911176e108a229d2e582d8151ec4f9cd9c6",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b5538fd48a28",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 234
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55309458d7d",
+		"isPrimary": true,
+		"legacyChartID": "139e0919bf61c968715c26c7f82e526c57078084",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5538fd48a28",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 234
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b553878ca5c2",
+		"isPrimary": true,
+		"legacyChartID": "dd6c84fd2038e351a7c3a9ba25e345e2675b7206",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5538fd48a28",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 236
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b553aa60ff4e",
+		"isPrimary": true,
+		"legacyChartID": "4323231cba1f4a6ec7fe79a832e62951054ae743",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b553925f0f46",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 236
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553c1ce2e81",
+		"isPrimary": true,
+		"legacyChartID": "40df3375c6a45edf383049cb1afff32001bc04ed",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b553925f0f46",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 236
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55303fed91d",
+		"isPrimary": true,
+		"legacyChartID": "97852db7bda62a6ffaf0495dc527e32eb1dae8d4",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b553925f0f46",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 243
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55300f7ec02",
+		"isPrimary": true,
+		"legacyChartID": "1584990973d058c2c9af08f60927ff1a10f5884d",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b5539ad4cac0",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 243
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5534e8f757b",
+		"isPrimary": true,
+		"legacyChartID": "48ff09d5055f15f0ee862cb78729c16146f15942",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5539ad4cac0",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 243
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5535c193b07",
+		"isPrimary": true,
+		"legacyChartID": "d27f64ef8f691c08307ea71144b371a855f3eedd",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b5539ad4cac0",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 230
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55349cc40e0",
+		"isPrimary": true,
+		"legacyChartID": "e7eaed619b016232f29d264d72f575dece095aa5",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b553a22da495",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 230
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553aab294f1",
+		"isPrimary": true,
+		"legacyChartID": "bb1f07881b252bc5983822429490035333f3cc14",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b553a22da495",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 230
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5533e8a19a8",
+		"isPrimary": true,
+		"legacyChartID": "7555f2f26b0e90e39c496762c258581a5f177c7f",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b553a22da495",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 248
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5537c38de91",
+		"isPrimary": true,
+		"legacyChartID": "fa4d091ea1b4de340a522e2e8bb36dd09d9af233",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b553a30c4123",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 248
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553bd2d1776",
+		"isPrimary": true,
+		"legacyChartID": "1ca5bbea80041b9c45de26fb9325bf4fa62486c6",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b553a30c4123",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 248
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55366fdcf50",
+		"isPrimary": true,
+		"legacyChartID": "43cd0b331b849cc5e52678fc50455a8e57b63ff4",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b553a30c4123",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 232
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55310e9644a",
+		"isPrimary": true,
+		"legacyChartID": "78c6ac0778f6493447f7a64f60894e84765fb351",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b553d6c5c9f9",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 232
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553a38f45fa",
+		"isPrimary": true,
+		"legacyChartID": "547439e369d7bda7ce577cf7c97557194fe907ed",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b553d6c5c9f9",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 232
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5532696c379",
+		"isPrimary": true,
+		"legacyChartID": "c7e42d6d7e75c9c900e618355b5b1a6df52db893",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b553d6c5c9f9",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 235
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5534fafb8a9",
+		"isPrimary": true,
+		"legacyChartID": "b4a76266edba861b94bf219e1ff63baac3cfac93",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b553d7c2258a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 235
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55345be3f14",
+		"isPrimary": true,
+		"legacyChartID": "1a5727e248e0b8f4887ec93bca9e505716db219e",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b553d7c2258a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 235
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55307e10c88",
+		"isPrimary": true,
+		"legacyChartID": "a5e280b830741c1adf74e99c889c76d9b12900a4",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b553d7c2258a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 244
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5533517d2bc",
+		"isPrimary": true,
+		"legacyChartID": "bb8937e9df9af96d08f6a0d1bd75918e87bf0db9",
+		"level": "1",
+		"levelNum": 1,
+		"songID": "S19e3de7b553dee87e26",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 244
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553a5a23966",
+		"isPrimary": true,
+		"legacyChartID": "538dac50ca28ede82c4e385b62282eafe4efa5cb",
+		"level": "0",
+		"levelNum": 0,
+		"songID": "S19e3de7b553dee87e26",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 244
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b553f36703d0",
+		"isPrimary": true,
+		"legacyChartID": "6d9017869e98245b5cae26892145401fdd03ac90",
+		"level": "0",
+		"levelNum": 0,
+		"songID": "S19e3de7b553dee87e26",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 239
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5534123b87b",
+		"isPrimary": true,
+		"legacyChartID": "8ec58f1adc0c030f6317030d1f08f67e8daa1164",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b553e4cf3aeb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 239
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b553822bf39f",
+		"isPrimary": true,
+		"legacyChartID": "f0a521a49736c828557d33f59b734c73d438ac36",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b553e4cf3aeb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 239
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b553dfe3adef",
+		"isPrimary": true,
+		"legacyChartID": "4af07669ddc30b1fc15cc3072b12ed5182806b20",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b553e4cf3aeb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 264
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55412738714",
+		"isPrimary": true,
+		"legacyChartID": "605e13bfaf41795e4933b72b330441644f9d87df",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5540eaf93f7",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 264
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5542f48bbcc",
+		"isPrimary": true,
+		"legacyChartID": "b3a8dae290ed30d9312212b91b0d335b6ef9b48f",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5540eaf93f7",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 264
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5541c6aecd9",
+		"isPrimary": true,
+		"legacyChartID": "c271fdf6074b86c3a609d96cca28508804d90eba",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b5540eaf93f7",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 263
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554f63bdcb8",
+		"isPrimary": true,
+		"legacyChartID": "e46bc8a9980707d8a0a8de804cdb893b7d145a27",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b554112d64d3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 263
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55434e5bf4d",
+		"isPrimary": true,
+		"legacyChartID": "ae82f7d2824e0deb3c4ff1a86bdcdb3d8a3c5c7c",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b554112d64d3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 263
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554e7ad68c8",
+		"isPrimary": true,
+		"legacyChartID": "b0ccb61d1cd736d2f3d8a221ee14ea414081f78a",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b554112d64d3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 273
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5542aa57f36",
+		"isPrimary": true,
+		"legacyChartID": "8f96a68b7367ee3c67e16d132d3461453ba2dc21",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5541ac1b534",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 273
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5547ff94cf5",
+		"isPrimary": true,
+		"legacyChartID": "e8ae13d038a0ab33761aaf27659cba50838877e2",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5541ac1b534",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 273
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554ce6977ef",
+		"isPrimary": true,
+		"legacyChartID": "3106405c40eaa6182f1458c4a35d4bb5742c548b",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b5541ac1b534",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 255
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554a08d4059",
+		"isPrimary": true,
+		"legacyChartID": "17edf457d980705a330968ef019fead977f2cb67",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5541c152856",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 255
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554b7b9b4af",
+		"isPrimary": true,
+		"legacyChartID": "5a03f775666f58f7e9443ebddc952736e433e972",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5541c152856",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 255
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554b461bba4",
+		"isPrimary": true,
+		"legacyChartID": "bf782f642667afa621ddf1b6474ff8618ab8d19c",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5541c152856",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 270
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554463d2e90",
+		"isPrimary": true,
+		"legacyChartID": "538db85d9674a3d121a7d8ec38ab593611fe9b42",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b5541f37cec8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 270
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55460ae4b43",
+		"isPrimary": true,
+		"legacyChartID": "0c6e4ed80468e5a21d0949c52b7a5abcda7520b7",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5541f37cec8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 270
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554b25b3b47",
+		"isPrimary": true,
+		"legacyChartID": "aaea1fbe5f3834a9d74faaac85bff43a1151c414",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b5541f37cec8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 271
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55421453fc7",
+		"isPrimary": true,
+		"legacyChartID": "ba0821f0cf35db2433b0683d0ed3c19ef00c54df",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b5542865a6ef",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 271
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554ca3e1e59",
+		"isPrimary": true,
+		"legacyChartID": "5e51b2dd568776a897bfa4c9cb828658bed13acb",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5542865a6ef",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 271
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5542f10f794",
+		"isPrimary": true,
+		"legacyChartID": "34d6392cf4cba125d103795b7e95feadad4a2cf0",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5542865a6ef",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 269
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554823d0973",
+		"isPrimary": true,
+		"legacyChartID": "b7a0d649001aed74e5266ce72c37f55ff806e9b4",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b5542db4a4c6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 269
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5549c5d65bc",
+		"isPrimary": true,
+		"legacyChartID": "815fbb496e76c49a64335f19da7540f73bb8b791",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5542db4a4c6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 269
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5548d3959b7",
+		"isPrimary": true,
+		"legacyChartID": "ca59c1df7bd8e5860fdf03cdc7ba0ae81a45315d",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b5542db4a4c6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 251
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554297ebe39",
+		"isPrimary": true,
+		"legacyChartID": "1042093cbfe66ad29aedb6c9e0819392fa7e83b1",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b5542e5cadbd",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 251
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5540e0bb6a4",
+		"isPrimary": true,
+		"legacyChartID": "91306a5f6e29c3de1e4574a09ee7f2707449321e",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5542e5cadbd",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 251
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554f852a68f",
+		"isPrimary": true,
+		"legacyChartID": "a3533e7bf9dfdf0e57dd257d1f115bf0b03bdc38",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5542e5cadbd",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 268
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554072f96df",
+		"isPrimary": true,
+		"legacyChartID": "81689f7a9082b30db5b8d7424e5367a8221bbd1f",
+		"level": "1",
+		"levelNum": 1,
+		"songID": "S19e3de7b55450502c16",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 268
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5540c054a39",
+		"isPrimary": true,
+		"legacyChartID": "0e024823b738cbca5e8a7bd4e491eca8604399fe",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55450502c16",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 268
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55449c88bf7",
+		"isPrimary": true,
+		"legacyChartID": "d294c7ae95852e178199ec99a76a40de0c8b4844",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b55450502c16",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 258
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554b9423edf",
+		"isPrimary": true,
+		"legacyChartID": "69d30d601fc8299b12481a092aa8ad6cbce1550b",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b5545bc77178",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 258
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554a401a9c0",
+		"isPrimary": true,
+		"legacyChartID": "3396d35e75ee8f6af5bca68c24785fe2f67f2fe8",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b5545bc77178",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 258
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554c34868b1",
+		"isPrimary": true,
+		"legacyChartID": "ee4da93f5821c6f99966925f36235b2c46b7049d",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5545bc77178",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 256
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554e1b87bfb",
+		"isPrimary": true,
+		"legacyChartID": "626075c0a48cc712dd727b6b94074adc9e0f534f",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b554608fea8f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 256
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554ee5a74db",
+		"isPrimary": true,
+		"legacyChartID": "2a3af2cf9ea3c83753976b6b0151d6db0281f0fd",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b554608fea8f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 256
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5544ce33cbf",
+		"isPrimary": true,
+		"legacyChartID": "3449fdb48a251f47fdebe38cdd43273a353b1848",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b554608fea8f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 253
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55476016d50",
+		"isPrimary": true,
+		"legacyChartID": "887de1225821618070e06f7a79715ab8e4a2e1a1",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b55462fb2575",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 253
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5543be5d070",
+		"isPrimary": true,
+		"legacyChartID": "e6fc096d6ef66c37d0c2506e8db7dc83519a2506",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b55462fb2575",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 253
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55428722a8d",
+		"isPrimary": true,
+		"legacyChartID": "ac599209c90fcdd5aaab972826446f1bb20b00b3",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55462fb2575",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 272
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55443479d68",
+		"isPrimary": true,
+		"legacyChartID": "8e5bf31c5be3e4e81d9faea5285111925502a16d",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55483760be3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 272
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554d361c827",
+		"isPrimary": true,
+		"legacyChartID": "abb2b4b5648419395e909ba5c9fda7d213fb158b",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55483760be3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 272
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554a554a9f4",
+		"isPrimary": true,
+		"legacyChartID": "4ae097f6658e2ce58c5e6dd64a75047187bb9e9d",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b55483760be3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 259
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554717267b4",
+		"isPrimary": true,
+		"legacyChartID": "b97b2d756c89661f430fa0370992b00e0cf53f13",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b554904fd531",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 259
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55434662866",
+		"isPrimary": true,
+		"legacyChartID": "5217404403ea04d107ee73148c6c3eaea1baf651",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b554904fd531",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 259
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554f704af0e",
+		"isPrimary": true,
+		"legacyChartID": "b0a1a967af045941f9e44227295f77888577a4f9",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b554904fd531",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 265
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554c5a70d88",
+		"isPrimary": true,
+		"legacyChartID": "e487a652546c73324d74de08a38e6ed5b159f1bb",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b55490ff7be8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 265
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554889212d4",
+		"isPrimary": true,
+		"legacyChartID": "68d724d46d3f97ca0a4d7a4cc54c2aa1ba3a3cda",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b55490ff7be8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 265
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554e0c60ae9",
+		"isPrimary": true,
+		"legacyChartID": "3a746a61bcdcde35bc2378ef697f1a256a5ed779",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b55490ff7be8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 257
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554bfcb43d7",
+		"isPrimary": true,
+		"legacyChartID": "f14a2f38481c5e83e283e38ba35a6de0efa0d52d",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b554936e7a0f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 257
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554d446a3a3",
+		"isPrimary": true,
+		"legacyChartID": "ba983566e9ccecfa5d4d9fcee7cd1c82fbd01e5b",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b554936e7a0f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 257
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55405574c8e",
+		"isPrimary": true,
+		"legacyChartID": "f5fadc7f8e56dadce4f83659f9d0dec6fac35ac5",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b554936e7a0f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 274
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55426b1a171",
+		"isPrimary": true,
+		"legacyChartID": "4d16fdaa593de5f3200aaaa07f9eb12919052f39",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5549c57c637",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 274
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5555c38362a",
+		"isPrimary": true,
+		"legacyChartID": "cb2eea9e2e29a425e3c49474354051217b4b666d",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5549c57c637",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 274
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554665e4324",
+		"isPrimary": true,
+		"legacyChartID": "d90ea9769a9972267ab4ae6c1fe5a864574f3a62",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b5549c57c637",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 262
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554db41e50c",
+		"isPrimary": true,
+		"legacyChartID": "258f46871ce9e09e16bd759e0c3e6bd867f83b41",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b554a26ffe61",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 262
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55463eb12d6",
+		"isPrimary": true,
+		"legacyChartID": "819aea9baaf93475bff39c68639b90ae4b7e07fd",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b554a26ffe61",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 262
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554734c5b35",
+		"isPrimary": true,
+		"legacyChartID": "1df373af3d683b18b966204ac2d89ae4db015581",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b554a26ffe61",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 266
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554bbdb2de4",
+		"isPrimary": true,
+		"legacyChartID": "b14536595a40ea896bc7590811c5146438eee6fe",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b554a8114368",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 266
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5542487648c",
+		"isPrimary": true,
+		"legacyChartID": "66d3d593144c98823469d6a513e73bfeb4edac33",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b554a8114368",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 266
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5545f7fd5cc",
+		"isPrimary": true,
+		"legacyChartID": "beab674fca5c49c5711e34a7edee125b1738e6e3",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b554a8114368",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 252
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5549d8858a2",
+		"isPrimary": true,
+		"legacyChartID": "edf824951f806156814dc80b4b11fc4eb6e4d27a",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b554a823c649",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 252
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554ad584351",
+		"isPrimary": true,
+		"legacyChartID": "915d9ef75f63b5dad5393ad2c9df1bc4f1bc1c24",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b554a823c649",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 252
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5547ae2faae",
+		"isPrimary": true,
+		"legacyChartID": "3fe6fb105aa0792a5d81500be94d2c1cf939b1bc",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b554a823c649",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 261
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55451255bb9",
+		"isPrimary": true,
+		"legacyChartID": "82dd51f011d6456790e2b6dee0e401a925226601",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b554b72613ce",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 261
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554a2cd56cd",
+		"isPrimary": true,
+		"legacyChartID": "b3022fd3e200e5e5d31a2d18a0440db4b7cebd9a",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b554b72613ce",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 261
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5549a484ee2",
+		"isPrimary": true,
+		"legacyChartID": "cba564b3849dda20bb4a69942bb696459d468427",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b554b72613ce",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 254
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5544e6b81b1",
+		"isPrimary": true,
+		"legacyChartID": "ca4e5a66167f0efedf2a13b186200f84b32c315b",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b554ccb0320e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 254
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554748e1c00",
+		"isPrimary": true,
+		"legacyChartID": "2c163620d89e05900302ea9e980300d169a03493",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b554ccb0320e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 254
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554f64643db",
+		"isPrimary": true,
+		"legacyChartID": "a7f7e21c31b531a7b8f6e8bbeb663d25f077743f",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b554ccb0320e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 260
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55414047e61",
+		"isPrimary": true,
+		"legacyChartID": "ec49b7b5f5befcad3ebfe8dcf23a4a90f149c401",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b554e69463eb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 260
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554b30f257c",
+		"isPrimary": true,
+		"legacyChartID": "14ad5d29d2bfaf5c32cf2b7240065cded8b4d96b",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b554e69463eb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 260
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b554ec1c6f8f",
+		"isPrimary": true,
+		"legacyChartID": "4025568a62b9563fa29d6edb73f44d0a670f9c18",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b554e69463eb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 267
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b554073eb523",
+		"isPrimary": true,
+		"legacyChartID": "b4cc83180a5722c86c068e13496ce5e7197fbebc",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b554f2f5f2b3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 267
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b554ef13018d",
+		"isPrimary": true,
+		"legacyChartID": "a2207cc5bf51f1a8cb798d355e7037ec141ebdf9",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b554f2f5f2b3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 267
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5542737c524",
+		"isPrimary": true,
+		"legacyChartID": "f86ce0a9ef0b02ad337ae52cf8ecfc74098bc83a",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b554f2f5f2b3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 278
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555d832a735",
+		"isPrimary": true,
+		"legacyChartID": "94bb1f0ae3ca5db0aaffcd4bd7de530b7cabdef6",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5550fe9181c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 278
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555ea83b582",
+		"isPrimary": true,
+		"legacyChartID": "f762329e0c363b78299623f9bc7db24dec19bee4",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5550fe9181c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 278
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555ad1adea5",
+		"isPrimary": true,
+		"legacyChartID": "db0c345877f680e5098a2ea50d014c571685059c",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b5550fe9181c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 299
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5550483ef5d",
+		"isPrimary": true,
+		"legacyChartID": "d469cfbddd0a7def8b94efea5cef76219608b332",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5551538db1f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 299
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55597d8efc5",
+		"isPrimary": true,
+		"legacyChartID": "ca338e501888adabb33176df2c31ac16fa1c35de",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5551538db1f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 299
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55565131d9b",
+		"isPrimary": true,
+		"legacyChartID": "4df8e5bb7381d2292cba8f030b71f73627e14227",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b5551538db1f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 277
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555f982c228",
+		"isPrimary": true,
+		"legacyChartID": "8b6a833f375408d47fa14fdba57f344ec1c1d279",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b55517cb6e91",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 277
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555911481b1",
+		"isPrimary": true,
+		"legacyChartID": "a7ca9a2d28a097abc536dd77a564e48effbc4a68",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55517cb6e91",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 277
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555f35490f1",
+		"isPrimary": true,
+		"legacyChartID": "d344d4ffd13b939b4fc69d94114f57a4b1d62951",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b55517cb6e91",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 283
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555c538c8b0",
+		"isPrimary": true,
+		"legacyChartID": "9d27b00755e9220a428cecd7ce85cee0911baa70",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b5552b54e61c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 283
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55505c61152",
+		"isPrimary": true,
+		"legacyChartID": "6426fd7846381f68f00e1102b948923bde52655e",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5552b54e61c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 283
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555523c8807",
+		"isPrimary": true,
+		"legacyChartID": "37e2b1cf6fa0f4a47447609505f6fb4678579a40",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b5552b54e61c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 291
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55558dce5e2",
+		"isPrimary": true,
+		"legacyChartID": "0aeaacdaea261cd1a8c1f6fa9b9ee3e3825f22c5",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b555338a551b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 291
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55591670682",
+		"isPrimary": true,
+		"legacyChartID": "b116ec02b22c752ff82b9a7e4d2cba33af2ef933",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b555338a551b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 291
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55521a3531a",
+		"isPrimary": true,
+		"legacyChartID": "19db0573c35f0655889f768ed3c352ab54bef871",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b555338a551b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 300
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555a998bbd6",
+		"isPrimary": true,
+		"legacyChartID": "5c43a238b551b974cfbadfb59821ca6119a38c97",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5553dab67e1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 300
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5565270a732",
+		"isPrimary": true,
+		"legacyChartID": "5025e3c73c53ba5f94b865394313904fd2e572ca",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5553dab67e1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 300
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55636b490e7",
+		"isPrimary": true,
+		"legacyChartID": "96d1f6b44bd06a9ad284763560cea0982109dec2",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b5553dab67e1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 280
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55507255564",
+		"isPrimary": true,
+		"legacyChartID": "57c0129414a66f6926ef198b07d2760535fec74b",
+		"level": "1",
+		"levelNum": 1,
+		"songID": "S19e3de7b5553fec9225",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 280
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55531e03999",
+		"isPrimary": true,
+		"legacyChartID": "0b6dd9a1daee3ec12dfbe08ec57cd56ce5ad2792",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5553fec9225",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 280
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5558cd71af8",
+		"isPrimary": true,
+		"legacyChartID": "b2fe4d81882519c2ec0d2c7b070e51c712cb7477",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b5553fec9225",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 282
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5550a0f1ee8",
+		"isPrimary": true,
+		"legacyChartID": "9ea97744ee81b558842e08b47b204155c26cb93e",
+		"level": "2",
+		"levelNum": 2,
+		"songID": "S19e3de7b5554c3d78f3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 282
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555c1c07042",
+		"isPrimary": true,
+		"legacyChartID": "6802f07b24034110f98f7f9a47dbc8fe3befecc5",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5554c3d78f3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 282
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5556b79eacc",
+		"isPrimary": true,
+		"legacyChartID": "de6839b95f759ad1d33397c940f2a257eaeec631",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5554c3d78f3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 279
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5557f97a0c4",
+		"isPrimary": true,
+		"legacyChartID": "f717feafb4250b0f72c8741a6bb1eeb538f698ec",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b55552ea857d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 279
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55530f3bc73",
+		"isPrimary": true,
+		"legacyChartID": "b123a4fc853594c69c0eecb71ed28154ba461b11",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b55552ea857d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 279
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55551d6da66",
+		"isPrimary": true,
+		"legacyChartID": "0e6be7326a7f32d86eabe0d350fd68d633279195",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55552ea857d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 286
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55592d7a03e",
+		"isPrimary": true,
+		"legacyChartID": "8aafe2f4693ae7083e1d2aed724bb7f783cba919",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b55561401176",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 286
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55506ed8eed",
+		"isPrimary": true,
+		"legacyChartID": "3c85522b533b2894c802c8b727307618a64b3959",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55561401176",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 286
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555c8f8b78e",
+		"isPrimary": true,
+		"legacyChartID": "dda04233966d633be3cdeb7dd3d88fb9ef0841ba",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b55561401176",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 288
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555a4bcc021",
+		"isPrimary": true,
+		"legacyChartID": "20d91e4318cdd62ef7ad60f7e79072891c0496a9",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b555702366ac",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 288
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55534e02728",
+		"isPrimary": true,
+		"legacyChartID": "934da027f2b612f57e15c5a9ac7a8ec51879f41b",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b555702366ac",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 288
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5555dd82aa9",
+		"isPrimary": true,
+		"legacyChartID": "14a46fe6be6f859973ce560cfbd1b0738f403553",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b555702366ac",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 296
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5555363fc90",
+		"isPrimary": true,
+		"legacyChartID": "c4100d4c434efdb146f5f3768aea80b1b6b72bd3",
+		"level": "1",
+		"levelNum": 1,
+		"songID": "S19e3de7b555842120f2",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 296
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55555645e07",
+		"isPrimary": true,
+		"legacyChartID": "a0a0a22ecd2b79e303a86f88ea9aa49dd8bc512a",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b555842120f2",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 296
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5554175b32e",
+		"isPrimary": true,
+		"legacyChartID": "3dfe170d71293e4ccc317bf0ea5a1c27af5cda66",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b555842120f2",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 293
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55501ee1616",
+		"isPrimary": true,
+		"legacyChartID": "72cd1d40bc62736ddb5f0222bd90a94b6b3b2fee",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5558caf613e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 293
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555c2244e97",
+		"isPrimary": true,
+		"legacyChartID": "e4de87f69e60811ee53ec554c7cd125ad273c7aa",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5558caf613e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 293
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5551b542ebc",
+		"isPrimary": true,
+		"legacyChartID": "80effb5042130da7f8fda5bf7849763a7aa6daef",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b5558caf613e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 298
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555ab6ae725",
+		"isPrimary": true,
+		"legacyChartID": "9579956216fae12edd9f281f6b47264531061b80",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b555998c019f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 298
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555f5915652",
+		"isPrimary": true,
+		"legacyChartID": "77faf124acd877980b0d7b1561dd51e8fae0c2a3",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b555998c019f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 298
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5557a73472a",
+		"isPrimary": true,
+		"legacyChartID": "cd812a3bee679a0f9bac4f5c087b813e77784f96",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b555998c019f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 292
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5555f54c858",
+		"isPrimary": true,
+		"legacyChartID": "a865de40bace2336f30f5bd831e697c13b56237a",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b5559fe856b1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 292
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555046a1c1f",
+		"isPrimary": true,
+		"legacyChartID": "ec8606720ab152790c68bf07c7d0fb4beabe15cc",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b5559fe856b1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 292
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555c9ee926c",
+		"isPrimary": true,
+		"legacyChartID": "10c361fa5da1b1c9d11ba9ab9d00a74cf3d35732",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5559fe856b1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 290
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55598f36d7f",
+		"isPrimary": true,
+		"legacyChartID": "8c830219724a17a1922786b602cda3c7b7df59f5",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b555ad4c7526",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 290
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5550b012ec1",
+		"isPrimary": true,
+		"legacyChartID": "dc3f947dc406a837810d0a652635e4a51d38fd37",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b555ad4c7526",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 290
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555386e7b6c",
+		"isPrimary": true,
+		"legacyChartID": "36694d13c27da1e24a08e7925a48578f5caf1eb7",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b555ad4c7526",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 295
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555178785aa",
+		"isPrimary": true,
+		"legacyChartID": "e558fa325a0d6e927f527dbcda86c8231ca359a6",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b555b0c0349e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 295
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5557b5e7fab",
+		"isPrimary": true,
+		"legacyChartID": "1f11f9764c84bcb6bfba13de5d914d6c73fd6ee0",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b555b0c0349e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 295
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5552e72a8ce",
+		"isPrimary": true,
+		"legacyChartID": "8652496a0453539dfe16caae1d909801ccada238",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b555b0c0349e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 276
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55542267315",
+		"isPrimary": true,
+		"legacyChartID": "c222b11ba94fd0511cc6a2fb239047a95c230201",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b555b898eaaf",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 276
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555cf83a97e",
+		"isPrimary": true,
+		"legacyChartID": "c63076da13dfd5754d6d93776861dbcd4465a1c2",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b555b898eaaf",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 276
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555f2ca23dd",
+		"isPrimary": true,
+		"legacyChartID": "b2e618499c3eb08681b4f7c1174cb7dd059a4236",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b555b898eaaf",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 289
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5551dfcf5da",
+		"isPrimary": true,
+		"legacyChartID": "8fbdf9febd31521774916ca9eaea75f6bc5f07bd",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b555c16202dc",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 289
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5551f02e607",
+		"isPrimary": true,
+		"legacyChartID": "1e403645c8839b1298acae4f09c9e3128f7aff4a",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b555c16202dc",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 289
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555ddbf0445",
+		"isPrimary": true,
+		"legacyChartID": "0aaddc735d12c86cc587a90249259780a7150f25",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b555c16202dc",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 281
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5558b2779bd",
+		"isPrimary": true,
+		"legacyChartID": "38d390ca6b4298015eef6ca2ca4079b688f2eaaf",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b555cc84429d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 281
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55530344dfb",
+		"isPrimary": true,
+		"legacyChartID": "62a57f9a3eb784656b38eab04b089a8573e0ee28",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b555cc84429d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 281
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555fdf7b85f",
+		"isPrimary": true,
+		"legacyChartID": "8d8ed9a121c139be7d6ef153896b6ab6ce1f83f4",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b555cc84429d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 275
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5553e17f54c",
+		"isPrimary": true,
+		"legacyChartID": "6e89064360c5d7d537132745348259061758c108",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b555cf9a251d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 275
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5550a317a56",
+		"isPrimary": true,
+		"legacyChartID": "cd565d001580e228af81260791f6938a9b75ab3d",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b555cf9a251d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 275
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5550bde4e70",
+		"isPrimary": true,
+		"legacyChartID": "fe5e90a8a93b1c867ebf2ba9cd0de948bbc95c01",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b555cf9a251d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 285
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555c8d21f4c",
+		"isPrimary": true,
+		"legacyChartID": "d55136e47b62af88fbd9a3e0cd0ddf9eacf9061e",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b555de598c67",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 285
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555ccad52d4",
+		"isPrimary": true,
+		"legacyChartID": "b31826de0fa8962dedf240e324bb87595373a5d2",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b555de598c67",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 285
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55505bca052",
+		"isPrimary": true,
+		"legacyChartID": "a630331442804b84cc107748a81f5ea6672d4c9e",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b555de598c67",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 294
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555b0c04b53",
+		"isPrimary": true,
+		"legacyChartID": "2d0758683ae931cab1ef2daf94d320eaea74a190",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b555de670a99",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 294
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5556d0e44e2",
+		"isPrimary": true,
+		"legacyChartID": "7684a7543df7a6fe195610a234f5b4018f061520",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b555de670a99",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 294
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5558c99fc91",
+		"isPrimary": true,
+		"legacyChartID": "32ecf2ea21d44dc4c6a83a573fa8f9382478d81b",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b555de670a99",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 287
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55524f50f0a",
+		"isPrimary": true,
+		"legacyChartID": "cf24358ac5c70631e9e115a3b56641548ac4b723",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b555e76df56c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 287
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555c2ae59a2",
+		"isPrimary": true,
+		"legacyChartID": "2ee0bcb73265e1a4ad0df8b4b0c0d8b46b41c74e",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b555e76df56c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 287
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555c0fc925d",
+		"isPrimary": true,
+		"legacyChartID": "14faf5ce41911edad04b13717cb155a88afca48c",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b555e76df56c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 297
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5550feefa36",
+		"isPrimary": true,
+		"legacyChartID": "6bc555359a0198c96706d9358e9de576b238d094",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b555edadfda8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 297
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5559f884c78",
+		"isPrimary": true,
+		"legacyChartID": "806736abb12b301b1187e155df67099f17593e7a",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b555edadfda8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 297
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555584221fe",
+		"isPrimary": true,
+		"legacyChartID": "be5259236aa9d0fdbadfb930172159ca25a094a0",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b555edadfda8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 284
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b555b6a01738",
+		"isPrimary": true,
+		"legacyChartID": "5ceb19d1cfc395d0fddf65b0af87bc3501dac64f",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b555f007cc90",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 284
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b555eb7b9e26",
+		"isPrimary": true,
+		"legacyChartID": "e90da03424d2dc3d24c75c67753ec7d8703698e3",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b555f007cc90",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 284
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b555ec3fdafb",
+		"isPrimary": true,
+		"legacyChartID": "5f3c1d217f09879a2530af11db6ed2697c7f6577",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b555f007cc90",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 323
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5565b8f4b89",
+		"isPrimary": true,
+		"legacyChartID": "84106c0297df947014ec46d39b210eb806d62a92",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b55608428d09",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 323
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556b38df0c4",
+		"isPrimary": true,
+		"legacyChartID": "3c637f6f208e221a555ce0b2e456925e0824d6d5",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55608428d09",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 323
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5562947531a",
+		"isPrimary": true,
+		"legacyChartID": "98336335d2c45561f6a39b6a5ec139a10e291772",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b55608428d09",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 311
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b556da190561",
+		"isPrimary": true,
+		"legacyChartID": "ae86c1acd86c923cbf6b64a854dcf1cd7dbb55cd",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5560ebfa5d6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 311
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5566cf2691f",
+		"isPrimary": true,
+		"legacyChartID": "c0d15774ab83c166da66cf450b57ca0c16752695",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b5560ebfa5d6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 311
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55637bc5370",
+		"isPrimary": true,
+		"legacyChartID": "4ed20e132de6980e86d5c8b121b967235e397c1e",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5560ebfa5d6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 324
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b556478148fc",
+		"isPrimary": true,
+		"legacyChartID": "c6df6e3521c574494de034e3755b0ecbe6a01d83",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b5561a07002d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 324
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556ac342d46",
+		"isPrimary": true,
+		"legacyChartID": "4697c929715e4b27d63002fac85dd24671198f5e",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b5561a07002d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 324
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b556f86db89b",
+		"isPrimary": true,
+		"legacyChartID": "bc47e8d15952e8cb3997ea6ae2c419a524035966",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5561a07002d",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 301
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5562f6bdf76",
+		"isPrimary": true,
+		"legacyChartID": "1937d114f81224c972b97fcdcb99907168f6fd24",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5561f3833f2",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 301
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5563f7c4143",
+		"isPrimary": true,
+		"legacyChartID": "fd88ad586deb18c89ac546ddbb57fed0be143521",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5561f3833f2",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 301
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b556788f4564",
+		"isPrimary": true,
+		"legacyChartID": "48b8498878627d500597fa16a132e024b11f8964",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b5561f3833f2",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 307
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5569c4462a9",
+		"isPrimary": true,
+		"legacyChartID": "43af05092c337fb6ff85045cae5d8eb66a2fc671",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55620f2ef1a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 307
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556a09d4030",
+		"isPrimary": true,
+		"legacyChartID": "b15b137b7aca31afedd02b0d8b164e44cda202fc",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55620f2ef1a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 307
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5569cffc89b",
+		"isPrimary": true,
+		"legacyChartID": "83b215a6d5629004244b18ae200cee2116c95fad",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b55620f2ef1a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 312
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55696db63aa",
+		"isPrimary": true,
+		"legacyChartID": "aae97fa7991f26b63ad558157ecc987765415c0b",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b55623343764",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 312
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55646e15afd",
+		"isPrimary": true,
+		"legacyChartID": "8b4fa3d995409c1c90a3aa6e938c89097423c7f2",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55623343764",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 312
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5563ad05aaa",
+		"isPrimary": true,
+		"legacyChartID": "affa9f53d9b8c7c31113f209d8e65a4f7e7fb14f",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b55623343764",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 305
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5560aface16",
+		"isPrimary": true,
+		"legacyChartID": "780a89b229e0c84b8913a5eb1b449982d11c751d",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55626bd4a5a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 305
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556eb484fc6",
+		"isPrimary": true,
+		"legacyChartID": "ae8abfe51e94220e7b628b58ab1773a3c90edc18",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b55626bd4a5a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 305
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55611004a2f",
+		"isPrimary": true,
+		"legacyChartID": "f7bdaf662ad1fbe94f9d6d61bd5585fd44636d31",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b55626bd4a5a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 316
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55642287909",
+		"isPrimary": true,
+		"legacyChartID": "0cef85ad68c9dceb5f6971e4df3dce7be1596c14",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b556377a7766",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 316
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5566f707246",
+		"isPrimary": true,
+		"legacyChartID": "dee0490f065833b97cf8d8e67d01313ff48e6eea",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b556377a7766",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 316
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b556dbe9b90b",
+		"isPrimary": true,
+		"legacyChartID": "de833340e4a60ce8ae726495086e2bde0b0c9335",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b556377a7766",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 302
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b556866d10c6",
+		"isPrimary": true,
+		"legacyChartID": "832e3b1ec8e9b2e5b1ec743cacce2ad4b5c4b5f9",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55655833141",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 302
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5560ca13c33",
+		"isPrimary": true,
+		"legacyChartID": "c7e3c69938d0c4b8739241106bd5b1cfde795152",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55655833141",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 302
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5560df0a067",
+		"isPrimary": true,
+		"legacyChartID": "cf7ec4e86994a6fa5be233602f47d3e386e2a229",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b55655833141",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 303
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5560a4ced62",
+		"isPrimary": true,
+		"legacyChartID": "2526c66c526601ffd167def72a8c6afec0a139e8",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b55666fef487",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 303
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556e1108945",
+		"isPrimary": true,
+		"legacyChartID": "6859713983d712abf9d95d2538114c705a92ea41",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b55666fef487",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 303
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55677a53117",
+		"isPrimary": true,
+		"legacyChartID": "f7635fe347e617cc385925408867c90da2ae41c0",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55666fef487",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 319
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55674516d07",
+		"isPrimary": true,
+		"legacyChartID": "ed6fad14ee65416f1ee4431cbff82283ed578092",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55667c17e9a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 319
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55616a5de40",
+		"isPrimary": true,
+		"legacyChartID": "92b4bb82889f1e14936804536401412d7ceadf12",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55667c17e9a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 319
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b556a0f83634",
+		"isPrimary": true,
+		"legacyChartID": "b066d0c71e359f889c7736ec8f0edec5467147e1",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b55667c17e9a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 308
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5565359350f",
+		"isPrimary": true,
+		"legacyChartID": "0c3e46f7df63d1b34b92121ad6a573128b2bf097",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b55672fafc97",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 308
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55655f819d7",
+		"isPrimary": true,
+		"legacyChartID": "2a24c1d1b48d9bb1b187330d76fecbabe054c9f0",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55672fafc97",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 308
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b556d5878a68",
+		"isPrimary": true,
+		"legacyChartID": "716a4829adfb3700ebb4308ac9d6320e7a6871b8",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b55672fafc97",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 317
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b556bcca60af",
+		"isPrimary": true,
+		"legacyChartID": "dc55d213454bc51a74877c8c2a8c14130b247f5e",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b556757a67b8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 317
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55628661999",
+		"isPrimary": true,
+		"legacyChartID": "ae9013e42b97c8700616b6647b6385afd8af8269",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b556757a67b8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 317
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5564e6b115e",
+		"isPrimary": true,
+		"legacyChartID": "4aaee5b2c235f3f71c2962dcb0032943e0fb224f",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b556757a67b8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 310
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55624ad4c20",
+		"isPrimary": true,
+		"legacyChartID": "5f6d0bd9cb980140086a9eeffe3c1546e74ad0c7",
+		"level": "2",
+		"levelNum": 2,
+		"songID": "S19e3de7b556773cca85",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 310
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556e68bfecd",
+		"isPrimary": true,
+		"legacyChartID": "7e6690a5212075d0e1cc5e6839ae2517bc786eee",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b556773cca85",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 310
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55699a1d8b6",
+		"isPrimary": true,
+		"legacyChartID": "336fcd047b406f81d03f46d90b63dc9120e8b846",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b556773cca85",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 306
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b556c80b8a50",
+		"isPrimary": true,
+		"legacyChartID": "bde8bb4d771bf5ac83a329bc48634c5da3489463",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b556856c65c0",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 306
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556b805e561",
+		"isPrimary": true,
+		"legacyChartID": "51e42e912c47740cec3d1db27e86c1324f923a1c",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b556856c65c0",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 306
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5561cfab8d3",
+		"isPrimary": true,
+		"legacyChartID": "067e37bca35613bf688daa9f35194b2acc1296c5",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b556856c65c0",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 315
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55615598002",
+		"isPrimary": true,
+		"legacyChartID": "6f6c19a53239d9c3e18fba5a211f926076bc450c",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b5568626025f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 315
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5560bb764ed",
+		"isPrimary": true,
+		"legacyChartID": "03c1fa45d9edb36bafddfcda6f6b851fb1f9219a",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b5568626025f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 315
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5561124af8a",
+		"isPrimary": true,
+		"legacyChartID": "789ca9b73d8b8267bcdb12a0179d20f12f7b8010",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5568626025f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 320
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b556ac8e926d",
+		"isPrimary": true,
+		"legacyChartID": "115af0bf757c25bbea40da650a8270c963a37608",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b556864e3e8e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 320
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5566b822746",
+		"isPrimary": true,
+		"legacyChartID": "95dc53a2569f29c7e36dcbc4f4817f06d09a54ae",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b556864e3e8e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 320
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b556b3c37085",
+		"isPrimary": true,
+		"legacyChartID": "bc523f1895299e2debe7f9b9d9fe80b5d3a7bbe4",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b556864e3e8e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 304
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55644722cfd",
+		"isPrimary": true,
+		"legacyChartID": "a89b8d1a9cbd24dff8b48f5a755581877726797f",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b5568daf0fdc",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 304
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55661164fc6",
+		"isPrimary": true,
+		"legacyChartID": "cee7869620a8aad99c0141d0ffc3bade3bd4292c",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b5568daf0fdc",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 304
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55638777159",
+		"isPrimary": true,
+		"legacyChartID": "239eef59f6f218223b47e4be0af47206bee466cf",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5568daf0fdc",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 321
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5567e72e28b",
+		"isPrimary": true,
+		"legacyChartID": "0a99c1d887bf04b968b1abd26cdcf4ccb014e20b",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b5569a561f00",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 321
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5563dd9e819",
+		"isPrimary": true,
+		"legacyChartID": "ff489f594e6d287c9a55e10d50bf87d2ad5fe14a",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5569a561f00",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 321
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5566db8602a",
+		"isPrimary": true,
+		"legacyChartID": "45cc70a647093bb1413d35e9e12edf2aa4d1645a",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b5569a561f00",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 322
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b556c39d8f7c",
+		"isPrimary": true,
+		"legacyChartID": "4c5aed114fb5c7c84e7c0b4d988131a2d8f5a963",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b5569db21712",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 322
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556ab6ac185",
+		"isPrimary": true,
+		"legacyChartID": "69077180e9691b79f5bf040519658d05e6ab987e",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5569db21712",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 322
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5569313c42f",
+		"isPrimary": true,
+		"legacyChartID": "9e7ab0e6f960ccb5d9b4a7da607b596dfd6749ac",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b5569db21712",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 314
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b556d550d8ad",
+		"isPrimary": true,
+		"legacyChartID": "74d04fd7dc7ff4e871d61ee4617a1f176432b95a",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b556a704043c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 314
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5566a1f74ae",
+		"isPrimary": true,
+		"legacyChartID": "4b26c35a39b0da73ac46355ed9b946a49a3fba82",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b556a704043c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 314
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55621ffa0eb",
+		"isPrimary": true,
+		"legacyChartID": "7beca7a9d304ca05dd220c50e6ed35ca2dcdb0ec",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b556a704043c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 313
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5567514b506",
+		"isPrimary": true,
+		"legacyChartID": "636e89f2f1c16fc1b894ff922e13c99900bdc15d",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b556e53e327c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 313
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55683df9565",
+		"isPrimary": true,
+		"legacyChartID": "22dc4c403c35a4681c111dbdefb32bcedd3eedda",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b556e53e327c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 313
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b556450ad2e7",
+		"isPrimary": true,
+		"legacyChartID": "3c63d8129760dd48583748ec3eb7ef43e5b177c5",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b556e53e327c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 309
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5564dd8ee92",
+		"isPrimary": true,
+		"legacyChartID": "25628957ae2f873ba31b09840210f9c17667ecb3",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b556eb8af1b1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 309
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556c8d2f8fb",
+		"isPrimary": true,
+		"legacyChartID": "526bf34a5eb23e40b540f5899759bb865f0a231a",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b556eb8af1b1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 309
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b556f0f8a0bb",
+		"isPrimary": true,
+		"legacyChartID": "9ef00410a5cb1a84014cacffacadc8d20c1635ab",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b556eb8af1b1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 318
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5561d519c36",
+		"isPrimary": true,
+		"legacyChartID": "0cb86fa9e4eb11627b55957627d3e94969c3aa19",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b556f16623e7",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 318
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b556dce9ed8e",
+		"isPrimary": true,
+		"legacyChartID": "2f121d0fc2c35c7675446bf688fbf8c67dc304ec",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b556f16623e7",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 318
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b556d5617293",
+		"isPrimary": true,
+		"legacyChartID": "15d9d1d09ccb07c4daaaed1968aa02e798b9d871",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b556f16623e7",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 341
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55785cde41d",
+		"isPrimary": true,
+		"legacyChartID": "e61e41e2c1ca68b8410bd6204d987c3a0378b41f",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b557070c2526",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 341
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557d70b70a9",
+		"isPrimary": true,
+		"legacyChartID": "a0fff96f85302817cbc4e02ea88ada3d1b92bf42",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b557070c2526",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 341
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b557a27ab0b1",
+		"isPrimary": true,
+		"legacyChartID": "b4bd4ae808095cb1ff5d01a25e821a350224e5a6",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b557070c2526",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 342
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5579aebd0db",
+		"isPrimary": true,
+		"legacyChartID": "b72049b1ffebb192242bf7a79e265078c84a2d8c",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b557080a0fa5",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 342
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5578a3f9823",
+		"isPrimary": true,
+		"legacyChartID": "c187ee85f08a738ac4825e5413770c5a03e28fae",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b557080a0fa5",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 342
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b557ac4d1aa0",
+		"isPrimary": true,
+		"legacyChartID": "7cc96987f9c9017bed244d935214d9fcf444a1a3",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b557080a0fa5",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 328
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557987ed511",
+		"isPrimary": true,
+		"legacyChartID": "56e146177c00b5c785bf9ae9627ffdbd35558bf4",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5570f01a965",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 328
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55716eb99b6",
+		"isPrimary": true,
+		"legacyChartID": "32f293ddfa9d983a97cbbcad4d964e9e1d335ab0",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5570f01a965",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 328
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5577744357b",
+		"isPrimary": true,
+		"legacyChartID": "9e27ea323a75ee6c4a987212afe386362a586276",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b5570f01a965",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 325
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557700ead5f",
+		"isPrimary": true,
+		"legacyChartID": "4086aa401df174d8b778b5b813b56734b7715cf0",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b55722974852",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 325
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557d84bf6f7",
+		"isPrimary": true,
+		"legacyChartID": "88ff486b1db29936ce64e9c3a6dcbac262d4d4f1",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b55722974852",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 325
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b557c200a772",
+		"isPrimary": true,
+		"legacyChartID": "4af1e898c42328d3e6ccd130810081670d363313",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55722974852",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 350
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557fbc30e60",
+		"isPrimary": true,
+		"legacyChartID": "d4d8f9bc61a4f47872a4f2118cfe38ba8934fdb2",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b5573c421821",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 350
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557d50d5bff",
+		"isPrimary": true,
+		"legacyChartID": "3ce182c8a97dc7c629b29caf60f1d167f25a4bc2",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5573c421821",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 350
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55738635167",
+		"isPrimary": true,
+		"legacyChartID": "8ddfced4468635dd920cf370a7c4cd377904f9ee",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b5573c421821",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 352
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557a3543c74",
+		"isPrimary": true,
+		"legacyChartID": "3240cbceb106d2bf8fac88248336be9af3bf0163",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5575827420c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 352
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5580a74fc60",
+		"isPrimary": true,
+		"legacyChartID": "2f9643d0561bb7fd61cdf429d4f4d2b92efd7d18",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5575827420c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 352
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558213c8490",
+		"isPrimary": true,
+		"legacyChartID": "d311607767e43289c6d0b7931a1b603727130b48",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5575827420c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 331
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557f9867fd6",
+		"isPrimary": true,
+		"legacyChartID": "ad085128189cbe48996a0298d0fcd8a8c1fd79b7",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b5578036c81e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 331
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557b0921c0d",
+		"isPrimary": true,
+		"legacyChartID": "6e16931c3d5e8f6275956132faa65d9937aced81",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5578036c81e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 331
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5572d89134d",
+		"isPrimary": true,
+		"legacyChartID": "94436d9a684e9d68451ac1714000ddb97f0dd60c",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5578036c81e",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 330
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55795f06465",
+		"isPrimary": true,
+		"legacyChartID": "68f2728049bb28f4d4a24bab405d8c28ac0042b2",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b5578870c0de",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 330
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557485dcf69",
+		"isPrimary": true,
+		"legacyChartID": "8741a79b6c240d184c444056b305c16a204be50a",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5578870c0de",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 330
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55718ca273d",
+		"isPrimary": true,
+		"legacyChartID": "373c79897dc805a7efccf5f1d01a049240ed8367",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b5578870c0de",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 338
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557b18e7d87",
+		"isPrimary": true,
+		"legacyChartID": "3b3db254c2cfe23b2eec25a835bf4f8b9be32f06",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5579eba8a33",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 338
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557f3cf9860",
+		"isPrimary": true,
+		"legacyChartID": "11cd01d740b8df085319e3a7fd165a990d652702",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b5579eba8a33",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 338
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5573998f7b4",
+		"isPrimary": true,
+		"legacyChartID": "96b49f5fcb6e4e20022049268509fa35108623a1",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5579eba8a33",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 347
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5571c534160",
+		"isPrimary": true,
+		"legacyChartID": "6700e737ca37b67a92c277cc1c7667c9df68c6e3",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5579f868ec1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 347
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557aced97ba",
+		"isPrimary": true,
+		"legacyChartID": "77bf3d612c77be2c0908a831ec295c5d3f7f8cd8",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5579f868ec1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 347
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5578ded9390",
+		"isPrimary": true,
+		"legacyChartID": "537730fdc7b2313673ab23f95a1bb99eba2715c2",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5579f868ec1",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 334
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5574108f16c",
+		"isPrimary": true,
+		"legacyChartID": "d654faa17ff7d9136571732cc41e412a66d3be24",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b557a2c9ea99",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 334
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557aad83a0d",
+		"isPrimary": true,
+		"legacyChartID": "f376d35b0ef853d3f9c709286e68f4cc99a38f03",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b557a2c9ea99",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 334
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5572cf84219",
+		"isPrimary": true,
+		"legacyChartID": "c39ba7e340964a9ce125a2e56900534e014ed3dd",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b557a2c9ea99",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 343
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5575b06fff4",
+		"isPrimary": true,
+		"legacyChartID": "0e55563b812858eb8214cfc262fc513a3745860a",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b557a76fc516",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 343
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55737e6d07d",
+		"isPrimary": true,
+		"legacyChartID": "41f62d6870a1dd33eafe9399821d3e437ef3e1ff",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b557a76fc516",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 343
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b557236ceb1b",
+		"isPrimary": true,
+		"legacyChartID": "35555e01d6ab3c94d173fe3bbb3297802002f273",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b557a76fc516",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 326
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55784fc39a2",
+		"isPrimary": true,
+		"legacyChartID": "c9a034bacd2a58be1df5e4524b54d8fc40e60ba1",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b557aac1ca80",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 326
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55700615394",
+		"isPrimary": true,
+		"legacyChartID": "b1398269889831962733afbc5dfefa0605fc5c30",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b557aac1ca80",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 326
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b557491b4866",
+		"isPrimary": true,
+		"legacyChartID": "e1da406d89ad01633cb9a4f86bb2de521d5780e8",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b557aac1ca80",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 329
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55773300001",
+		"isPrimary": true,
+		"legacyChartID": "3e501ff85dd129c31551f65bedfed0b485387003",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b557bb95cc20",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 329
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55712a49442",
+		"isPrimary": true,
+		"legacyChartID": "0e4596d3c533f1c749cbdf2def614c86f2825f40",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b557bb95cc20",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 329
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5570b5404a6",
+		"isPrimary": true,
+		"legacyChartID": "52fe245a86d7e39fc57e3f4ad3f49009f4a3cb53",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b557bb95cc20",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 327
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557207ca2f4",
+		"isPrimary": true,
+		"legacyChartID": "b96bb98d7b7ef72878342c8a35beb7f319d64c7b",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b557cb50dd35",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 327
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5579c9e11bc",
+		"isPrimary": true,
+		"legacyChartID": "ca9b464f168849212f1b812df791a54d09732c54",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b557cb50dd35",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 327
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5579378ecd6",
+		"isPrimary": true,
+		"legacyChartID": "1445a329bdb436fb8f3408a6144ac8d659974b0c",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b557cb50dd35",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 336
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557fbb7cc93",
+		"isPrimary": true,
+		"legacyChartID": "d50d2fb3ae17114d8609c72b1e373f76edfdecbf",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b557cf5aa0ab",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 336
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557ec75bb6b",
+		"isPrimary": true,
+		"legacyChartID": "8d138f9af3c44bc9b167dcb93aef5f0cb1bb4e01",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b557cf5aa0ab",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 336
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b557336cbbd0",
+		"isPrimary": true,
+		"legacyChartID": "84d4c594928cb1e46404c7c9bc42056de396bdc8",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b557cf5aa0ab",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 340
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557a826a9bb",
+		"isPrimary": true,
+		"legacyChartID": "ff2e9bbf8c9b8ce9c92851e249409f1e515b1eb5",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b557d4825b54",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 340
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5577c92ff9c",
+		"isPrimary": true,
+		"legacyChartID": "f60b48ced27e29a83e7e02a58206eec413f7bed5",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b557d4825b54",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 340
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b557d970e4fe",
+		"isPrimary": true,
+		"legacyChartID": "c3447c50c0a7e7f447dcbed97ef65b490a98bcd3",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b557d4825b54",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 335
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5572a41bc13",
+		"isPrimary": true,
+		"legacyChartID": "349d835a097309863c576d3aab236a5e68bd7c50",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b557db8a965f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 335
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5579695ecdb",
+		"isPrimary": true,
+		"legacyChartID": "c8f459acecce097c77b46e5993c5a58d804f40f0",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b557db8a965f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 335
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5573878ab42",
+		"isPrimary": true,
+		"legacyChartID": "fa98981016e78a28aa34dffef0cac1cf8486bab8",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b557db8a965f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 333
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b557e1e4646d",
+		"isPrimary": true,
+		"legacyChartID": "64e3167b13a221a4ffce47ee377e1a524a3cce39",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b557e361da02",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 333
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5574b0bb817",
+		"isPrimary": true,
+		"legacyChartID": "28f675a2fb15ae28b5924aad92213944cafc2414",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b557e361da02",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 333
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b557e949e7af",
+		"isPrimary": true,
+		"legacyChartID": "f80fa4562559e7081fece44e940eabfa22a00e5e",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b557e361da02",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 344
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5571dfc97fd",
+		"isPrimary": true,
+		"legacyChartID": "bb87b7670051fa046dfeba004f7446cb6022303e",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b557e44da743",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 344
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557187f92ea",
+		"isPrimary": true,
+		"legacyChartID": "94301c3edfc3165b35a2cf270bd89dcd595d2b13",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b557e44da743",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 344
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5570e38d9a3",
+		"isPrimary": true,
+		"legacyChartID": "858e231b40d7f2760d8f4d1579c42065b21732c2",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b557e44da743",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 337
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5570c829b44",
+		"isPrimary": true,
+		"legacyChartID": "050a08f686b26f560ab632d9cfe212ec1019ea82",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b557e9ad6756",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 337
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557808a60c7",
+		"isPrimary": true,
+		"legacyChartID": "8964695f19e2c1442a41815c42b6cd6fa498cde3",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b557e9ad6756",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 337
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5571e271602",
+		"isPrimary": true,
+		"legacyChartID": "71eceea7094c46ce9158db196e5827d4e4c39975",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b557e9ad6756",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 349
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55756e26c68",
+		"isPrimary": true,
+		"legacyChartID": "bc0c0d49a6d9b7dfa7709b4fe1fd927d6a23494b",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b557f3323505",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 349
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b557d0a0b2e4",
+		"isPrimary": true,
+		"legacyChartID": "1cf9279010e0e5efb7620d047c014d4a8f6342cc",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b557f3323505",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 349
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55777a67600",
+		"isPrimary": true,
+		"legacyChartID": "42135ea00dd27c400801dff905d36ca5965cd60a",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b557f3323505",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 332
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5578d03326d",
+		"isPrimary": true,
+		"legacyChartID": "2271faed8c6cb9a5218e131f832278d7f1cf4fe6",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b557f4669ba8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 332
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5571daf141b",
+		"isPrimary": true,
+		"legacyChartID": "9d74f723a00b663a5cfef161bdd2a4aa6e58bf78",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b557f4669ba8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 332
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b557c90e7ebc",
+		"isPrimary": true,
+		"legacyChartID": "f2fc6b2671d63eb5ee66a7a4575db503f3c213ee",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b557f4669ba8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 476
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55887a5ef3b",
+		"isPrimary": true,
+		"legacyChartID": "396e183d9a6f3eeaccee68bf4b86a185eb033009",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55800e6591a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 476
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558e5f9569c",
+		"isPrimary": true,
+		"legacyChartID": "00374f2e0bba54865e011fda3cbf92f10add2bf7",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b55800e6591a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 476
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55800f0f7fb",
+		"isPrimary": true,
+		"legacyChartID": "fc052185c36a18f0a0faa5db0c58ed2713716d92",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b55800e6591a",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 354
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558eeeb7348",
+		"isPrimary": true,
+		"legacyChartID": "d037135723c762328f9317ed63787a4cc3ddceb3",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b55812bd0914",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 354
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55832a32bc1",
+		"isPrimary": true,
+		"legacyChartID": "6eb695e6dd869cb54395ce356e793dada94a7867",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55812bd0914",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 354
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558f74926df",
+		"isPrimary": true,
+		"legacyChartID": "246f5c5d0e8076b618f55356cc110d80ec406059",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b55812bd0914",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 463
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558effbcadf",
+		"isPrimary": true,
+		"legacyChartID": "73a0517913e5df882a0a00244c5dc47caf44407e",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55815a18884",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 463
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5582d0dbe63",
+		"isPrimary": true,
+		"legacyChartID": "3b6a12b5952cd1834d43ea0b64fc53e949e3ce4f",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b55815a18884",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 463
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55867560f02",
+		"isPrimary": true,
+		"legacyChartID": "eafed58a09ff5760d089c1143054696e8eaac6d6",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b55815a18884",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 388
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5581382669c",
+		"isPrimary": true,
+		"legacyChartID": "fca694b3bd998e860f477277be6764c9714cebc8",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b55815be8ec6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 388
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5581bd7fa2f",
+		"isPrimary": true,
+		"legacyChartID": "034a1258f77d24d927f27e245db2c60774764b3e",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b55815be8ec6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 388
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5582fe358e1",
+		"isPrimary": true,
+		"legacyChartID": "71a31414efc799bb5e614235c22c5aed1a2255b0",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b55815be8ec6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 394
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558808b2876",
+		"isPrimary": true,
+		"legacyChartID": "f0e9052d05087ddaa8977445d0e08f19f118adad",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55815f04091",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 394
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558d7d8edd5",
+		"isPrimary": true,
+		"legacyChartID": "0974bc7b38b6a32fa9f416390e4ee1300849d395",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b55815f04091",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 394
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55829e06a1d",
+		"isPrimary": true,
+		"legacyChartID": "a741ff39bac493580758df5e3f55afc83f6be4c7",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b55815f04091",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 368
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558594d7c1c",
+		"isPrimary": true,
+		"legacyChartID": "9ae6dd924cdd36b5496685c6bffea0c304bb78fa",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b55819b3a0b8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 368
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55812d7ba48",
+		"isPrimary": true,
+		"legacyChartID": "a1bb13a4a9eb6d66cde00abfaaa92f0f6041b820",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55819b3a0b8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 368
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558883d99de",
+		"isPrimary": true,
+		"legacyChartID": "c5c8521c71bb9ad11e6e3357a5474d84f38e9bb2",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b55819b3a0b8",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 366
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55888525718",
+		"isPrimary": true,
+		"legacyChartID": "b69168f78a8a7d9e3a28ee815e0e3430c1747e8f",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b558374b8b8f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 366
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5589d19cb1d",
+		"isPrimary": true,
+		"legacyChartID": "27cffc05c0f4fc60f9b36ffc4c00707189e8eaaf",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b558374b8b8f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 366
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55869e01c12",
+		"isPrimary": true,
+		"legacyChartID": "6dbca14f5a4189de921dff536ce4f696284e57ff",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b558374b8b8f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 374
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55821a16ec4",
+		"isPrimary": true,
+		"legacyChartID": "0ac9ec671c2469eb49c5f0f916a5e3a23cff17cf",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5583ad77bbf",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 374
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558c22b6a74",
+		"isPrimary": true,
+		"legacyChartID": "42be2977688fbcd2d617bffe1b2262e5df48dae1",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5583ad77bbf",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 374
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5581bef6369",
+		"isPrimary": true,
+		"legacyChartID": "1f8c79d0e8d3c3f7c99131a6ae31899da7bdf333",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b5583ad77bbf",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 361
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5584bc533f4",
+		"isPrimary": true,
+		"legacyChartID": "722726e8b2d5b139554ffd36839d7ebe77f5607e",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b558416b0dcb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 361
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558eebba28d",
+		"isPrimary": true,
+		"legacyChartID": "790fa69d00c3881f34d3fc3a3b7c92d6a2cd9bbe",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b558416b0dcb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 361
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558da61a6ee",
+		"isPrimary": true,
+		"legacyChartID": "81edc1804a539eda58c3154c2da4d4b808043457",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b558416b0dcb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 373
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5582f4ab2f2",
+		"isPrimary": true,
+		"legacyChartID": "9a1677122c4c0f537c1e0e6de2c157a66a89cbc1",
+		"level": "2",
+		"levelNum": 2,
+		"songID": "S19e3de7b5585377c2c7",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 373
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5586c439966",
+		"isPrimary": true,
+		"legacyChartID": "56ff31369db6d42b92837e05404560055fac2283",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5585377c2c7",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 373
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55840ea8b95",
+		"isPrimary": true,
+		"legacyChartID": "abbe555582497f5207f08fd0beaceb57986ec067",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5585377c2c7",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 557
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558897c5b37",
+		"isPrimary": true,
+		"legacyChartID": "90187e2ae0e42b378a519d252d3454fbc46e81dc",
+		"level": "1",
+		"levelNum": 1,
+		"songID": "S19e3de7b5585b0a558b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 557
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5582c97c515",
+		"isPrimary": true,
+		"legacyChartID": "d6525a0fc5301961db7db2bbd492305b54ea6d10",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5585b0a558b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 557
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55897298312",
+		"isPrimary": true,
+		"legacyChartID": "59954733f193c2acc5ac5d04ab117d4f852279ce",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b5585b0a558b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 387
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558212a1363",
+		"isPrimary": true,
+		"legacyChartID": "55168564a16ea3f5647ec5b36a8d70855cd58800",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b5585d2c3bfd",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 387
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558ecbc831c",
+		"isPrimary": true,
+		"legacyChartID": "9c286ca2347eeaccd074eb6f7b1ae1886e4067d9",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5585d2c3bfd",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 387
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55864ac671f",
+		"isPrimary": true,
+		"legacyChartID": "8724198c6cc47db15871a616f6bc3cea8e922df5",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b5585d2c3bfd",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 365
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558cc6a2a85",
+		"isPrimary": true,
+		"legacyChartID": "7785a1064f94902a23bb4b9800c42c38fe233a7a",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5585e4316cc",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 365
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55806ab890e",
+		"isPrimary": true,
+		"legacyChartID": "cc5925db4697308d48502aa5649cc44b0293ced3",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b5585e4316cc",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 365
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5583f0e7631",
+		"isPrimary": true,
+		"legacyChartID": "30be7dc63bc81a48ee999d8df371cb62787a1590",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b5585e4316cc",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 364
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558e8d58509",
+		"isPrimary": true,
+		"legacyChartID": "daa412d482b4d725799d5fb3d78e1b84cb5d095a",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b55861002600",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 364
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5584c426984",
+		"isPrimary": true,
+		"legacyChartID": "05ed92b4f8563b0109f8ccbe61b1a79479556dee",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b55861002600",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 364
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5588bc1f087",
+		"isPrimary": true,
+		"legacyChartID": "0c652b2445d96dd8f1ac6a554f62c136a104f818",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55861002600",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 395
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55829596b08",
+		"isPrimary": true,
+		"legacyChartID": "f12cf2ad03e4ed4c7bb95518405f8239f4c5b6a3",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b55865bc305c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 395
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5589686875d",
+		"isPrimary": true,
+		"legacyChartID": "537438db374dc27f29357d9b675339f5b9bee63f",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b55865bc305c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 395
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558109036d3",
+		"isPrimary": true,
+		"legacyChartID": "6ab417cfefd413ac71569c84661d559fa23d655a",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b55865bc305c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 462
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558c947ced8",
+		"isPrimary": true,
+		"legacyChartID": "d4f64f50f335661dedf02b63c82866b609e72e09",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b558687a0903",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 462
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558c4c5d82d",
+		"isPrimary": true,
+		"legacyChartID": "1017e8eda7117e7ed62e51420ce749c730b33e90",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b558687a0903",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 462
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5582fba7c2b",
+		"isPrimary": true,
+		"legacyChartID": "064b27cdc6c058136fa06651d9c9b5bc29dbe0eb",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b558687a0903",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 358
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55846ea5cd1",
+		"isPrimary": true,
+		"legacyChartID": "feebb2fdcbcd3da8e61d4586bb0c33b22275b213",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5586f39bebb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 358
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55860f0ade6",
+		"isPrimary": true,
+		"legacyChartID": "581e21a0ba5481f8c764e9078dfae78242977004",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5586f39bebb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 358
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5582d5b7f16",
+		"isPrimary": true,
+		"legacyChartID": "aaa4f8d3834052d72f12e7faeca4bdaa7281c26f",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b5586f39bebb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 376
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55874879000",
+		"isPrimary": true,
+		"legacyChartID": "512792ece1d924824e121446f0263988a79ba9a7",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b55870fca583",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 376
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558d586377e",
+		"isPrimary": true,
+		"legacyChartID": "d29513166ff5ab77feb48c4948ba28b97e2e97f3",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55870fca583",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 376
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558684d25e4",
+		"isPrimary": true,
+		"legacyChartID": "c43a2176bc7693d0b658e4da087fe2a55946f074",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b55870fca583",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 464
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558529c2c68",
+		"isPrimary": true,
+		"legacyChartID": "e2af41e66637c90c2cc46c375630ead342952508",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19e3de7b558737ae13c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 464
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55803813645",
+		"isPrimary": true,
+		"legacyChartID": "e98ea8ff37fc145117e7e5d8982268a1e56460a7",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b558737ae13c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 464
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558807e30fa",
+		"isPrimary": true,
+		"legacyChartID": "363f5ea39fbb8afed763998b54d5f0b91a6bf49c",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b558737ae13c",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 554
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558bbeead7a",
+		"isPrimary": true,
+		"legacyChartID": "1834375e460d02af901dc5fbc03e78a388602c4c",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b55873e43297",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 554
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55833db651d",
+		"isPrimary": true,
+		"legacyChartID": "35152e5d3fd674bf275695dc9fecfba8fa2aa03e",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19e3de7b55873e43297",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 554
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558bd9cfa4a",
+		"isPrimary": true,
+		"legacyChartID": "4174745868e45ab91aba317fc39b340e929aa294",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b55873e43297",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 384
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5585136aa42",
+		"isPrimary": true,
+		"legacyChartID": "1b84af3acb4c00f61e927784ac3b071e9573a7ad",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55876652c93",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 384
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5586692fd82",
+		"isPrimary": true,
+		"legacyChartID": "d3dfb1fec5acdea3e9bc491e2fbdf8eee15a77b3",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55876652c93",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 384
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5581db1cb65",
+		"isPrimary": true,
+		"legacyChartID": "9987974eeb7f6667f1f44c0efa7dc89de198802a",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b55876652c93",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 392
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55891e30482",
+		"isPrimary": true,
+		"legacyChartID": "57a7a18f423aa11f95249c6ef2a8fff4ae4626e8",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b55880100e93",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 392
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558d9da46bd",
+		"isPrimary": true,
+		"legacyChartID": "da2275677ee783712ed5d2df31a7be17ba422940",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b55880100e93",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 392
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558b8ba3d25",
+		"isPrimary": true,
+		"legacyChartID": "4686378554157d06015207eaea43296d817c8ae4",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b55880100e93",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 386
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558aa2ff14e",
+		"isPrimary": true,
+		"legacyChartID": "9a136d1efd6f3421fd3b8ab450acecc1ec0f202c",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b55886985017",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 386
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558db8c8b33",
+		"isPrimary": true,
+		"legacyChartID": "fd214e44368f3a50f070ed52eac632a8202a4eea",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b55886985017",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 386
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558d6a02184",
+		"isPrimary": true,
+		"legacyChartID": "acc0ff60aacab0f806d06b6ee6794da6356ec77d",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b55886985017",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 561
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5584073a0f0",
+		"isPrimary": true,
+		"legacyChartID": "1c0f5f78c726ace011df7879fcfafa5534b263c8",
+		"level": "2",
+		"levelNum": 2,
+		"songID": "S19e3de7b5588a17cdf5",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 561
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55828e09b53",
+		"isPrimary": true,
+		"legacyChartID": "7f9a9afaea01f0fc921d6b995b9cac434248c7b5",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5588a17cdf5",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 561
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558251e0e60",
+		"isPrimary": true,
+		"legacyChartID": "2c63d83c11203352b9dda5da9d718a70acc4df6f",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b5588a17cdf5",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 579
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558136fda0d",
+		"isPrimary": true,
+		"legacyChartID": "89416b5434f2746bf4697ff5a7035bd2ddb7420c",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b5589cc17df3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 579
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5599ca770f7",
+		"isPrimary": true,
+		"legacyChartID": "a781823544f0029ff79be7f58c197c2948d0db2c",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b5589cc17df3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 579
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558416f3953",
+		"isPrimary": true,
+		"legacyChartID": "dadd8e2c9f133649fa1351c2b69a3b43ecb66b8e",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b5589cc17df3",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 359
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558bb2ea47c",
+		"isPrimary": true,
+		"legacyChartID": "3d6e1d71c98fab763dbb0604e5262260f2046857",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b558a2bc11ef",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 359
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5586af98594",
+		"isPrimary": true,
+		"legacyChartID": "e48125486047d1f661b7bc9ff26abc375834e254",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19e3de7b558a2bc11ef",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 359
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55808ba239f",
+		"isPrimary": true,
+		"legacyChartID": "818babb2410c44238222473ffb8f1e23e9fb7707",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b558a2bc11ef",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 371
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55836ab2fa6",
+		"isPrimary": true,
+		"legacyChartID": "87b10c552768bdebe0a92b64f8c739a177a280f9",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e3de7b558a739e7cb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 371
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b55859b632b3",
+		"isPrimary": true,
+		"legacyChartID": "1933080c8ed84826fee3535c6de322fe4ec89968",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b558a739e7cb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 371
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5581e6257c4",
+		"isPrimary": true,
+		"legacyChartID": "a60f1b3a7feb26dbfcef896fec4c0fc3c6b4f040",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e3de7b558a739e7cb",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 360
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5585dac32b1",
+		"isPrimary": true,
+		"legacyChartID": "15d266b2b50d051512e9e3bba92a57a95d6ba979",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b558b051a298",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 360
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558bf92f393",
+		"isPrimary": true,
+		"legacyChartID": "e9ead193bbcf4b45a606d583920162b100ef3da7",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b558b051a298",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 360
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5588b6d84e9",
+		"isPrimary": true,
+		"legacyChartID": "64532079f3d95795265585b2bfa6c6dce863328d",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b558b051a298",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 543
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5587c8f10d8",
+		"isPrimary": true,
+		"legacyChartID": "31b7fa8b6afc1e4f214c1037adacdeb1c294abc9",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b558b61e3b5b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 543
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5584470d946",
+		"isPrimary": true,
+		"legacyChartID": "489e54cbf8c04cd1cd066095ea66f54b6e59f96d",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b558b61e3b5b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 543
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55883c741ef",
+		"isPrimary": true,
+		"legacyChartID": "dfacadb7c2964e4c4a9874cd0907e364be0b347b",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b558b61e3b5b",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 525
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b55896eae3a9",
+		"isPrimary": true,
+		"legacyChartID": "8a487ffbadd085dc02265765673f343aaa3ad6ff",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19e3de7b558bc0e2ab6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 525
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5584d04a7f4",
+		"isPrimary": true,
+		"legacyChartID": "be32354c2c9158ce2cf6e7592bb43ae5b7f8111a",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b558bc0e2ab6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 525
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5580901a94e",
+		"isPrimary": true,
+		"legacyChartID": "735f8ea42ea858d320ec99275b88fe80dd579f66",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e3de7b558bc0e2ab6",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 389
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b5581592abad",
+		"isPrimary": true,
+		"legacyChartID": "43da43b76cec344c161ceac1d3b378ba505f8d55",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b558d650a37f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 389
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5585ec65f23",
+		"isPrimary": true,
+		"legacyChartID": "130e1edcce8061e67b922a4f53a4e38bad50c09a",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b558d650a37f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 389
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b55868f34844",
+		"isPrimary": true,
+		"legacyChartID": "02a1b75b21c11c4a332e7b82adc17aade9dffd3c",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e3de7b558d650a37f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 355
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558e2e38101",
+		"isPrimary": true,
+		"legacyChartID": "fd2c901322189180737fa95cd4f37bede123f699",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e3de7b558f2969f66",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 355
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b5586ee727f2",
+		"isPrimary": true,
+		"legacyChartID": "fd58d78f54fa530584a0a3f277893884bead4aad",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e3de7b558f2969f66",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 355
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b5586243c523",
+		"isPrimary": true,
+		"legacyChartID": "db5404ce553ff1d5671bd8bd5f72e788d0f6caa0",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b558f2969f66",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 375
+		},
+		"difficulty": "Green",
+		"id": "C19e3de7b558cdd8340e",
+		"isPrimary": true,
+		"legacyChartID": "8a7bdbf1f0bbb5b36131059762fa8d4ee0945047",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19e3de7b558fdcb6e6f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 375
+		},
+		"difficulty": "Red",
+		"id": "C19e3de7b558524f0832",
+		"isPrimary": true,
+		"legacyChartID": "b2b416abb6e6d3ac5b11156290318b8915f758ee",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19e3de7b558fdcb6e6f",
+		"versions": ["m+"]
+	},
+	{
+		"data": {
+			"inGameID": 375
+		},
+		"difficulty": "Yellow",
+		"id": "C19e3de7b558bc9fdbcc",
+		"isPrimary": true,
+		"legacyChartID": "bccdb047122dcf37484f981542c567826ef19748",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19e3de7b558fdcb6e6f",
+		"versions": ["m+"]
 	}
 ]

--- a/db/seeds/folders.json
+++ b/db/seeds/folders.json
@@ -35567,6 +35567,17 @@
 	},
 	{
 		"game": "museca",
+		"id": "F19e3e03e1379805a2ba",
+		"inactive": false,
+		"legacyFolderID": "F54d56fde06e349e7712483dca58c722cf0e69b57aa44e86d5d0d63c05d7da0ff",
+		"searchTerms": [],
+		"slug": "1-plus",
+		"title": "Level 1 (PLUS)",
+		"versionFilter": ["m+"],
+		"where": "chart.level = '1'"
+	},
+	{
+		"game": "museca",
 		"id": "F19d35f0cf2ae9c66857",
 		"inactive": false,
 		"legacyFolderID": "Fb5033381b613ec9aa09c2266e3fb3b77d0d6e1e24cb7c626b0ae6571b18e019b",
@@ -35585,6 +35596,17 @@
 		"slug": "10-1-5",
 		"title": "Level 10 (1 + 1/2)",
 		"versionFilter": ["1.5"],
+		"where": "chart.level = '10'"
+	},
+	{
+		"game": "museca",
+		"id": "F19e3e03e1373bc92d1a",
+		"inactive": false,
+		"legacyFolderID": "F60c2b15eaef11e44d79e350e8526378d81b09a863ca4c699ce52a9daf57f889d",
+		"searchTerms": [],
+		"slug": "10-plus",
+		"title": "Level 10 (PLUS)",
+		"versionFilter": ["m+"],
 		"where": "chart.level = '10'"
 	},
 	{
@@ -35611,6 +35633,17 @@
 	},
 	{
 		"game": "museca",
+		"id": "F19e3e03e137302b3dac",
+		"inactive": false,
+		"legacyFolderID": "Ff58fede29c0d273fa49c0981a09d9f3f523ce53c102ec37a81e886edf99f260e",
+		"searchTerms": [],
+		"slug": "11-plus",
+		"title": "Level 11 (PLUS)",
+		"versionFilter": ["m+"],
+		"where": "chart.level = '11'"
+	},
+	{
+		"game": "museca",
 		"id": "F19d35f0cf2a5399c930",
 		"inactive": false,
 		"legacyFolderID": "Feff48f2ba0c9a72ad2b7c10c9a64d8fbfaecb4336c008980c3c30b78a55631c2",
@@ -35629,6 +35662,17 @@
 		"slug": "12-1-5",
 		"title": "Level 12 (1 + 1/2)",
 		"versionFilter": ["1.5"],
+		"where": "chart.level = '12'"
+	},
+	{
+		"game": "museca",
+		"id": "F19e3e03e137ae55d6ce",
+		"inactive": false,
+		"legacyFolderID": "F037c91707a2ebab5998e37648b65b7a86a8d362bd2d8a1ac7fbf247bdf8e4f80",
+		"searchTerms": [],
+		"slug": "12-plus",
+		"title": "Level 12 (PLUS)",
+		"versionFilter": ["m+"],
 		"where": "chart.level = '12'"
 	},
 	{
@@ -35655,6 +35699,17 @@
 	},
 	{
 		"game": "museca",
+		"id": "F19e3e03e13709fca9ac",
+		"inactive": false,
+		"legacyFolderID": "Fac40a331b24c78be0b90d111c182048c95c2e5521bff23a9d275b415a2365867",
+		"searchTerms": [],
+		"slug": "13-plus",
+		"title": "Level 13 (PLUS)",
+		"versionFilter": ["m+"],
+		"where": "chart.level = '13'"
+	},
+	{
+		"game": "museca",
 		"id": "F19d35f0cf2ab229bd49",
 		"inactive": false,
 		"legacyFolderID": "Fb43a75d7eda130f0514abd297bbb4b4b09486c3ad81e0ecb18de2c5a968c7878",
@@ -35673,6 +35728,17 @@
 		"slug": "14-1-5",
 		"title": "Level 14 (1 + 1/2)",
 		"versionFilter": ["1.5"],
+		"where": "chart.level = '14'"
+	},
+	{
+		"game": "museca",
+		"id": "F19e3e03e137bf6efde1",
+		"inactive": false,
+		"legacyFolderID": "Fc6f75e1d6a14a6c52d397682a4ee74cbf9929d5ece668f287ce3106e3379c278",
+		"searchTerms": [],
+		"slug": "14-plus",
+		"title": "Level 14 (PLUS)",
+		"versionFilter": ["m+"],
 		"where": "chart.level = '14'"
 	},
 	{
@@ -35699,6 +35765,17 @@
 	},
 	{
 		"game": "museca",
+		"id": "F19e3e03e1376c913af0",
+		"inactive": false,
+		"legacyFolderID": "Fc84d7a2a3a2d1569e7a35e086ad874328375289bb890adb341ba1e22413015e5",
+		"searchTerms": [],
+		"slug": "15-plus",
+		"title": "Level 15 (PLUS)",
+		"versionFilter": ["m+"],
+		"where": "chart.level = '15'"
+	},
+	{
+		"game": "museca",
 		"id": "F19d35f0cf2af0957f2f",
 		"inactive": false,
 		"legacyFolderID": "F4b269bccaa0fd9a1bed1346aa2d168307c1baae5a4d076e994750ca0862098bd",
@@ -35717,6 +35794,17 @@
 		"slug": "16-1-5",
 		"title": "Level 16 (1 + 1/2)",
 		"versionFilter": ["1.5"],
+		"where": "chart.level = '16'"
+	},
+	{
+		"game": "museca",
+		"id": "F19e3e03e137cfba5fe3",
+		"inactive": false,
+		"legacyFolderID": "Fb093252b1f8c4642877c62114b07352be5f83a274ca5b542885b20242d7cb0ec",
+		"searchTerms": [],
+		"slug": "16-plus",
+		"title": "Level 16 (PLUS)",
+		"versionFilter": ["m+"],
 		"where": "chart.level = '16'"
 	},
 	{
@@ -35743,6 +35831,17 @@
 	},
 	{
 		"game": "museca",
+		"id": "F19e3e03e137d109cc98",
+		"inactive": false,
+		"legacyFolderID": "Fad3a7d5ded429ca323e3674f011581388c59d91938a5fa4e788fc0242bd9ab2c",
+		"searchTerms": [],
+		"slug": "2-plus",
+		"title": "Level 2 (PLUS)",
+		"versionFilter": ["m+"],
+		"where": "chart.level = '2'"
+	},
+	{
+		"game": "museca",
 		"id": "F19d35f0cf2a827a7d97",
 		"inactive": false,
 		"legacyFolderID": "Fbfd9a58fe40449df1628e18f9645b9c10e1208057ff48032067c4d81901d8c62",
@@ -35761,6 +35860,17 @@
 		"slug": "3-1-5",
 		"title": "Level 3 (1 + 1/2)",
 		"versionFilter": ["1.5"],
+		"where": "chart.level = '3'"
+	},
+	{
+		"game": "museca",
+		"id": "F19e3e03e137c68faa10",
+		"inactive": false,
+		"legacyFolderID": "F5356206e6eb1b3e58f935fdf0a46a287b656edcf6ae692bd3d5d9db633a312d9",
+		"searchTerms": [],
+		"slug": "3-plus",
+		"title": "Level 3 (PLUS)",
+		"versionFilter": ["m+"],
 		"where": "chart.level = '3'"
 	},
 	{
@@ -35787,6 +35897,17 @@
 	},
 	{
 		"game": "museca",
+		"id": "F19e3e03e137e0effdb3",
+		"inactive": false,
+		"legacyFolderID": "F104b87a4809acd970643f2d61c8be5ad6c0d9384bea5c2a913b4cfb206fb3aa0",
+		"searchTerms": [],
+		"slug": "4-plus",
+		"title": "Level 4 (PLUS)",
+		"versionFilter": ["m+"],
+		"where": "chart.level = '4'"
+	},
+	{
+		"game": "museca",
 		"id": "F19d35f0cf2a7fafef13",
 		"inactive": false,
 		"legacyFolderID": "F8a42c3dd3b48652e6f41658e5f767183ce5c253d7c999ecbe573144d7be04377",
@@ -35805,6 +35926,17 @@
 		"slug": "5-1-5",
 		"title": "Level 5 (1 + 1/2)",
 		"versionFilter": ["1.5"],
+		"where": "chart.level = '5'"
+	},
+	{
+		"game": "museca",
+		"id": "F19e3e03e13726fa9944",
+		"inactive": false,
+		"legacyFolderID": "F4be43a972d6f165623b57d2b251ade8b09c6b67edb4004671e589d451b6a0f6a",
+		"searchTerms": [],
+		"slug": "5-plus",
+		"title": "Level 5 (PLUS)",
+		"versionFilter": ["m+"],
 		"where": "chart.level = '5'"
 	},
 	{
@@ -35831,6 +35963,17 @@
 	},
 	{
 		"game": "museca",
+		"id": "F19e3e03e13758a3379f",
+		"inactive": false,
+		"legacyFolderID": "F10980d3ab7d62efcf1a00b847a247b288d6cefdfef25526eb63bb54a6a4117cd",
+		"searchTerms": [],
+		"slug": "6-plus",
+		"title": "Level 6 (PLUS)",
+		"versionFilter": ["m+"],
+		"where": "chart.level = '6'"
+	},
+	{
+		"game": "museca",
 		"id": "F19d35f0cf2ab398c79a",
 		"inactive": false,
 		"legacyFolderID": "Fb5e10fa9199fd1d9bdf8b7ae0f966c839f22ff636fbb5b7a2a3d4ba40bc43b69",
@@ -35849,6 +35992,17 @@
 		"slug": "7-1-5",
 		"title": "Level 7 (1 + 1/2)",
 		"versionFilter": ["1.5"],
+		"where": "chart.level = '7'"
+	},
+	{
+		"game": "museca",
+		"id": "F19e3e03e1379185e26f",
+		"inactive": false,
+		"legacyFolderID": "Ffe2dd17e6cab3da2b3f9b513db633415f3a5a3fe470705d491bafb383da05f8e",
+		"searchTerms": [],
+		"slug": "7-plus",
+		"title": "Level 7 (PLUS)",
+		"versionFilter": ["m+"],
 		"where": "chart.level = '7'"
 	},
 	{
@@ -35875,6 +36029,17 @@
 	},
 	{
 		"game": "museca",
+		"id": "F19e3e03e137306791b4",
+		"inactive": false,
+		"legacyFolderID": "F5e89fb8dbc0811a56f7a2f5a3c1a94c225f3e2ede99802ff81e7c2b6946071eb",
+		"searchTerms": [],
+		"slug": "8-plus",
+		"title": "Level 8 (PLUS)",
+		"versionFilter": ["m+"],
+		"where": "chart.level = '8'"
+	},
+	{
+		"game": "museca",
 		"id": "F19d35f0cf2ad6722ecb",
 		"inactive": false,
 		"legacyFolderID": "F87345cd5f190cbda888fad39e5de60fac215f9adc94c82fd99e2fbe1c7cdf4a0",
@@ -35893,6 +36058,17 @@
 		"slug": "9-1-5",
 		"title": "Level 9 (1 + 1/2)",
 		"versionFilter": ["1.5"],
+		"where": "chart.level = '9'"
+	},
+	{
+		"game": "museca",
+		"id": "F19e3e03e137a10d8865",
+		"inactive": false,
+		"legacyFolderID": "Fcc7edfdabc7943171652386ae37eb6d7a88fbb1e97ff63174778a59d7a98d242",
+		"searchTerms": [],
+		"slug": "9-plus",
+		"title": "Level 9 (PLUS)",
+		"versionFilter": ["m+"],
 		"where": "chart.level = '9'"
 	},
 	{

--- a/db/seeds/songs-museca.json
+++ b/db/seeds/songs-museca.json
@@ -1,7 +1,7 @@
 [
 	{
 		"altTitles": [],
-		"artist": "Last Note. feat. GUMI",
+		"artist": "Last Note． feat. GUMI",
 		"data": {
 			"artistJP": "ﾗｽﾄﾉｰﾄﾌｨｰﾁｬﾘﾝｸﾞｸﾞﾐ",
 			"displayVersion": "1",
@@ -147,7 +147,7 @@
 		"artist": "Music by MasKaleido, Vocal by ぁゅ",
 		"data": {
 			"artistJP": "ﾏｽｶﾚｲﾄﾞ",
-			"displayVersion": "1",
+			"displayVersion": "1.5-b",
 			"titleJP": "ｽﾀｰﾀﾞｽﾄﾏｰﾒｲﾄﾞ"
 		},
 		"id": "S19d35e0b42f6d1ef0bb",
@@ -212,7 +212,7 @@
 		"artist": "millstones",
 		"data": {
 			"artistJP": "ﾐﾙｽﾄｰﾝｽﾞ",
-			"displayVersion": "1",
+			"displayVersion": "1.5-b",
 			"titleJP": "ﾄﾏﾄﾘｰﾌﾌﾞﾚｲｸｽ"
 		},
 		"id": "S19d35e0b4348d400e96",
@@ -224,9 +224,9 @@
 		"altTitles": [],
 		"artist": "VALLEYSTONE feat. 紫崎 雪",
 		"data": {
-			"artistJP": "ﾊﾞﾘｰｽﾄｰﾝ ﾋｭｰﾁｬﾘﾝｸﾞ ｼｻﾞｷﾕｷ",
+			"artistJP": "ﾊﾞﾘｰｽﾄｰﾝﾋｭｰﾁｬﾘﾝｸﾞｼｻﾞｷﾕｷ",
 			"displayVersion": "1",
-			"titleJP": "ﾗﾌﾞｼｯｸ ﾗﾌﾞﾁｭｰﾝ"
+			"titleJP": "ﾗﾌﾞｼｯｸﾗﾌﾞﾁｭｰﾝ"
 		},
 		"id": "S19d35e0b435a966cff4",
 		"legacySongID": 18,
@@ -278,7 +278,7 @@
 		"data": {
 			"artistJP": "ｸﾛﾏ",
 			"displayVersion": "1",
-			"titleJP": "ﾎﾟﾝﾎﾟﾝﾎﾟﾝﾎﾟｺﾀﾞｲｾﾝｿｳ!"
+			"titleJP": "ﾎﾟﾝﾎﾟﾝﾎﾟﾝﾎﾟｺﾀﾞｲｾﾝｿｳ"
 		},
 		"id": "S19d35e0b439c7c2ca64",
 		"legacySongID": 22,
@@ -368,7 +368,7 @@
 		"artist": "C-Show",
 		"data": {
 			"artistJP": "ｼｼｮｳ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾕｰｴﾇｵｰｴﾝﾜｶﾉｼﾞｮﾅﾉｶﾄｰﾎﾘｯｸﾐｯｸｽ"
 		},
 		"id": "S19d35e0b4408cf2f105",
@@ -413,7 +413,7 @@
 		"id": "S19d35e0b44440c9f6eb",
 		"legacySongID": 33,
 		"searchTerms": [],
-		"title": "inverted RAINBOW (M齣SECA Ver.)"
+		"title": "inverted RAINBOW (MÚSECA Ver.)"
 	},
 	{
 		"altTitles": [],
@@ -433,7 +433,7 @@
 		"artist": "埼玉最終兵器",
 		"data": {
 			"artistJP": "ｻｲﾀﾏｻｲｼｭｳﾍｲｷ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾃﾝｸｳﾉﾊﾅﾉﾐﾔｺ"
 		},
 		"id": "S19d35e0b44658211805",
@@ -446,7 +446,7 @@
 		"artist": "XL Project -yanagizm side-",
 		"data": {
 			"artistJP": "ｴｸｾﾙﾌﾟﾛｼﾞｪｸﾄﾔﾅｷﾞｽﾞﾑｻｲﾄﾞ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾎｵｽﾞｷﾐﾀｲﾆｱｶｲﾀﾏｼｲｼﾞｮｳﾈﾂｽﾀｲﾙ"
 		},
 		"id": "S19d35e0b448ca11f6d5",
@@ -459,7 +459,7 @@
 		"artist": "アゴアニキ",
 		"data": {
 			"artistJP": "ｱｺﾞｱﾆｷ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾀﾞﾌﾞﾙﾗﾘｱｯﾄ"
 		},
 		"id": "S19d35e0b4491f73dd42",
@@ -498,7 +498,7 @@
 		"artist": "まふまふ",
 		"data": {
 			"artistJP": "ﾏﾌﾏﾌ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾊｰﾄﾉｱﾄｱｼﾞ"
 		},
 		"id": "S19d35e0b45165912643",
@@ -846,7 +846,7 @@
 	},
 	{
 		"altTitles": [],
-		"artist": "溝口ゆうま feat. みこ齶なち齶あい",
+		"artist": "溝口ゆうま feat. みこ♡なち♡あい",
 		"data": {
 			"artistJP": "ﾐｿﾞﾉｸﾁﾕｳﾏﾌｭｰﾁｬﾘﾝｸﾞﾐｺﾅﾁｱｲ",
 			"displayVersion": "1",
@@ -859,7 +859,7 @@
 	},
 	{
 		"altTitles": [],
-		"artist": "miko齶nachi feat.u-z",
+		"artist": "miko♡nachi feat.u-z",
 		"data": {
 			"artistJP": "ﾐｺﾊｰﾄﾅﾁﾌｨｰﾁｬﾘﾝｸﾞﾕｰｼﾞ",
 			"displayVersion": "1",
@@ -1089,7 +1089,7 @@
 		"id": "S19d35e0b47f5beefa69",
 		"legacySongID": 92,
 		"searchTerms": [],
-		"title": "齧rche"
+		"title": "Ärche"
 	},
 	{
 		"altTitles": [],
@@ -1187,7 +1187,7 @@
 		"artist": "Nem",
 		"data": {
 			"artistJP": "ﾈﾑ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ｱｱｽﾊﾞﾗｼｷﾆｬﾝｾｲ"
 		},
 		"id": "S19d35e0b488cde6f260",
@@ -1200,7 +1200,7 @@
 		"artist": "トーマ",
 		"data": {
 			"artistJP": "ﾄｰﾏ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾏﾎｳｼｮｳｼﾞｮｺｳﾌｸﾛﾝ"
 		},
 		"id": "S19d35e0b48a215882c2",
@@ -1213,7 +1213,7 @@
 		"artist": "M.S.S Project",
 		"data": {
 			"artistJP": "ｴﾑｴｽｴｽﾌﾟﾛｼﾞｪｸﾄ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ｴﾑｴｽｴｽﾌﾟﾗﾈｯﾄ"
 		},
 		"id": "S19d35e0b48bc9b3561d",
@@ -1239,7 +1239,7 @@
 		"artist": "n.k",
 		"data": {
 			"artistJP": "ｴﾇｹｰ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ｺﾉﾌｻﾞｹﾀｽﾊﾞﾗｼｷｾｶｲﾊ､ﾎﾞｸﾉﾀﾒﾆｱﾙ"
 		},
 		"id": "S19d35e0b48eed08c590",
@@ -1252,7 +1252,7 @@
 		"artist": "n-buna",
 		"data": {
 			"artistJP": "ﾅﾌﾞﾅ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾑｼﾞﾝｴｷ"
 		},
 		"id": "S19d35e0b48fab7c3dfa",
@@ -1278,7 +1278,7 @@
 		"artist": "Pa's Lam System",
 		"data": {
 			"artistJP": "ﾊﾟｽﾞﾗﾑｼｽﾃﾑ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ｲﾌ"
 		},
 		"id": "S19d35e0b4912dffb3b9",
@@ -1291,7 +1291,7 @@
 		"artist": "Yu_Asahina",
 		"data": {
 			"artistJP": "ﾕｳｱｻﾋﾅ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾌｧﾝｸｼｮﾝﾅﾝﾊﾞｰﾌｧｲﾌﾞ"
 		},
 		"id": "S19d35e0b492bcaa581a",
@@ -1304,7 +1304,7 @@
 		"artist": "Yunomi",
 		"data": {
 			"artistJP": "ﾕﾉﾐ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾐﾀﾗｼﾌﾟﾗﾄﾆｯｸﾌｨｰﾁｬﾘﾝｸﾞﾆｶﾓｷｭ"
 		},
 		"id": "S19d35e0b49326eb55c9",
@@ -1707,7 +1707,7 @@
 		"artist": "Daisuke Ohnuma",
 		"data": {
 			"artistJP": "ﾀﾞｲｽｹｵｵﾇﾏ",
-			"displayVersion": "15",
+			"displayVersion": "1.5",
 			"titleJP": "ｸﾗｯｸﾕｱｿｳﾙ"
 		},
 		"id": "S19d35e0b4b942b6dde2",
@@ -2643,12 +2643,2053 @@
 		"artist": "ぺのれり",
 		"data": {
 			"artistJP": "ﾍﾟﾉﾚﾘ",
-			"displayVersion": "1.5",
+			"displayVersion": "1.5-b",
 			"titleJP": "ｴｳﾞｧｰﾗｽﾃｨﾝｸﾞﾒｯｾｰｼﾞ"
 		},
 		"id": "S19d35e0b506c6a58ca7",
 		"legacySongID": 226,
 		"searchTerms": [],
 		"title": "Everlasting Message"
+	},
+	{
+		"altTitles": [],
+		"artist": "ハチ",
+		"data": {
+			"artistJP": "ﾊﾁ",
+			"displayVersion": "1.5",
+			"titleJP": "ﾏﾄﾘｮｼｶ"
+		},
+		"id": "S19e3dbc52e8666a9202",
+		"legacySongID": 41,
+		"searchTerms": [],
+		"title": "マトリョシカ"
+	},
+	{
+		"altTitles": [],
+		"artist": "ハチ",
+		"data": {
+			"artistJP": "ﾊﾁ",
+			"displayVersion": "1.5",
+			"titleJP": "ﾄﾞｰﾅﾂﾎｰﾙ"
+		},
+		"id": "S19e3dbc52e8acfb31ce",
+		"legacySongID": 42,
+		"searchTerms": [],
+		"title": "ドーナツホール"
+	},
+	{
+		"altTitles": [],
+		"artist": "ノマ",
+		"data": {
+			"artistJP": "ﾉﾏ",
+			"displayVersion": "1.5",
+			"titleJP": "ﾌﾞﾚｲﾝﾊﾟﾜｰ"
+		},
+		"id": "S19e3dbc52e8b0cef53e",
+		"legacySongID": 171,
+		"searchTerms": [],
+		"title": "Brain Power"
+	},
+	{
+		"altTitles": [],
+		"artist": "Dustup",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b552ae207f8b",
+		"legacySongID": 227,
+		"searchTerms": [],
+		"title": "1116"
+	},
+	{
+		"altTitles": [],
+		"artist": "日向美ビタースイーツ♪ & ここなつ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b552d3e81145",
+		"legacySongID": 229,
+		"searchTerms": [],
+		"title": "チョコレートスマイル"
+	},
+	{
+		"altTitles": [],
+		"artist": "日向美ビタースイーツ♪&日向美ブルームーン",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b552f857441b",
+		"legacySongID": 228,
+		"searchTerms": [],
+		"title": "琥珀のくちづけ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Sota Fujimori",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55313c6ba22",
+		"legacySongID": 241,
+		"searchTerms": [],
+		"title": "polygon"
+	},
+	{
+		"altTitles": [],
+		"artist": "海の底からマーメイド・Prim by ARM×狐夢想",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5531942fab4",
+		"legacySongID": 233,
+		"searchTerms": [],
+		"title": "ギョギョっと人魚・爆婚ブライダル"
+	},
+	{
+		"altTitles": [],
+		"artist": "Rche",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5531d6e4fd6",
+		"legacySongID": 242,
+		"searchTerms": [],
+		"title": "entelecheia"
+	},
+	{
+		"altTitles": [],
+		"artist": "U1 overground",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b553282fbbb4",
+		"legacySongID": 246,
+		"searchTerms": [],
+		"title": "Go For The Top"
+	},
+	{
+		"altTitles": [],
+		"artist": "COSIO",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5532a3d6a59",
+		"legacySongID": 249,
+		"searchTerms": [],
+		"title": "Rise Circuit"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nhato",
+		"data": {
+			"artistJP": "ﾝﾊﾄ",
+			"displayVersion": "m+",
+			"titleJP": "ﾏｼﾞｯｸ"
+		},
+		"id": "S19e3de7b553341da503",
+		"legacySongID": 240,
+		"searchTerms": [],
+		"title": "Magic"
+	},
+	{
+		"altTitles": [],
+		"artist": "TORIENA",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5533953052c",
+		"legacySongID": 237,
+		"searchTerms": [],
+		"title": "Chewingood!!!"
+	},
+	{
+		"altTitles": [],
+		"artist": "NU-KO",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5533dfeeee2",
+		"legacySongID": 245,
+		"searchTerms": [],
+		"title": "ポチコの幸せな日常"
+	},
+	{
+		"altTitles": [],
+		"artist": "U1 overground",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55340651487",
+		"legacySongID": 231,
+		"searchTerms": [],
+		"title": "Hunny Bunny"
+	},
+	{
+		"altTitles": [],
+		"artist": "Lite Show Magic (t+pazolite vs C-Show)",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b553465dd675",
+		"legacySongID": 238,
+		"searchTerms": [],
+		"title": "Crack Traxxxx"
+	},
+	{
+		"altTitles": [],
+		"artist": "Sakuzyo",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5534c452547",
+		"legacySongID": 247,
+		"searchTerms": [],
+		"title": "Imprinting"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ryu☆",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5536b62e0f1",
+		"legacySongID": 250,
+		"searchTerms": [],
+		"title": "I/O"
+	},
+	{
+		"altTitles": [],
+		"artist": "Eagle",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5538fd48a28",
+		"legacySongID": 234,
+		"searchTerms": [],
+		"title": "Boomy and The Boost"
+	},
+	{
+		"altTitles": [],
+		"artist": "7mai",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b553925f0f46",
+		"legacySongID": 236,
+		"searchTerms": [],
+		"title": "CUTE-Reflection"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remo-Con",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5539ad4cac0",
+		"legacySongID": 243,
+		"searchTerms": [],
+		"title": "EXTREMA PT.2"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ TOTTO",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b553a22da495",
+		"legacySongID": 230,
+		"searchTerms": [],
+		"title": "Windy Fairy"
+	},
+	{
+		"altTitles": [],
+		"artist": "隣の庭は青い(庭師+Aoi)",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b553a30c4123",
+		"legacySongID": 248,
+		"searchTerms": [],
+		"title": "遷"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ TOTTO",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b553d6c5c9f9",
+		"legacySongID": 232,
+		"searchTerms": [],
+		"title": "Astrogazer"
+	},
+	{
+		"altTitles": [],
+		"artist": "Tatsh feat.小田ユウ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b553d7c2258a",
+		"legacySongID": 235,
+		"searchTerms": [],
+		"title": "Change the World"
+	},
+	{
+		"altTitles": [],
+		"artist": "Xi",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b553dee87e26",
+		"legacySongID": 244,
+		"searchTerms": [],
+		"title": "Froge Dive"
+	},
+	{
+		"altTitles": [],
+		"artist": "KAN TAKAHIKO",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b553e4cf3aeb",
+		"legacySongID": 239,
+		"searchTerms": [],
+		"title": "Auto Click"
+	},
+	{
+		"altTitles": [],
+		"artist": "uno feat.ちよこ(IOSYS)",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5540eaf93f7",
+		"legacySongID": 264,
+		"searchTerms": [],
+		"title": "Twin Rocket"
+	},
+	{
+		"altTitles": [],
+		"artist": "TAG",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554112d64d3",
+		"legacySongID": 263,
+		"searchTerms": [],
+		"title": "Reb∞t"
+	},
+	{
+		"altTitles": [],
+		"artist": "rider",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5541ac1b534",
+		"legacySongID": 273,
+		"searchTerms": [],
+		"title": "Hexennacht"
+	},
+	{
+		"altTitles": [],
+		"artist": "うらら remixed by SLAKE",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5541c152856",
+		"legacySongID": 255,
+		"searchTerms": [],
+		"title": "魔法的新定義 electro mix"
+	},
+	{
+		"altTitles": [],
+		"artist": "こすも８ｂｉｔ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5541f37cec8",
+		"legacySongID": 270,
+		"searchTerms": [],
+		"title": "Story of 40KB"
+	},
+	{
+		"altTitles": [],
+		"artist": "MARON (IOSYS)",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5542865a6ef",
+		"legacySongID": 271,
+		"searchTerms": [],
+		"title": "BONE BORN"
+	},
+	{
+		"altTitles": [],
+		"artist": "seiya-murai feat. ALT",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5542db4a4c6",
+		"legacySongID": 269,
+		"searchTerms": [],
+		"title": "Spring Pain"
+	},
+	{
+		"altTitles": [],
+		"artist": "kors k",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5542e5cadbd",
+		"legacySongID": 251,
+		"searchTerms": [],
+		"title": "Virtual Sunrise"
+	},
+	{
+		"altTitles": [],
+		"artist": "マチゲリータ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55450502c16",
+		"legacySongID": 268,
+		"searchTerms": [],
+		"title": "不思議玩具ガンガラディンドン"
+	},
+	{
+		"altTitles": [],
+		"artist": "ここなつ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5545bc77178",
+		"legacySongID": 258,
+		"searchTerms": [],
+		"title": "ルミナスデイズ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ryu☆ feat. moimoi",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554608fea8f",
+		"legacySongID": 256,
+		"searchTerms": [],
+		"title": "OOO"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by DJ Command",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55462fb2575",
+		"legacySongID": 253,
+		"searchTerms": [],
+		"title": "Mermaid girl -秋葉工房 MIX-"
+	},
+	{
+		"altTitles": [],
+		"artist": "t+pazolite",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55483760be3",
+		"legacySongID": 272,
+		"searchTerms": [],
+		"title": "Tomorrow Perfume (tpz Despair Remix)"
+	},
+	{
+		"altTitles": [],
+		"artist": "Camellia",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554904fd531",
+		"legacySongID": 259,
+		"searchTerms": [],
+		"title": "Quaoar"
+	},
+	{
+		"altTitles": [],
+		"artist": "はがね",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55490ff7be8",
+		"legacySongID": 265,
+		"searchTerms": [],
+		"title": "Pulsar"
+	},
+	{
+		"altTitles": [],
+		"artist": "黒魔",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554936e7a0f",
+		"legacySongID": 257,
+		"searchTerms": [],
+		"title": "Space Diver Tama"
+	},
+	{
+		"altTitles": [],
+		"artist": "TECHNO MASTERS",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5549c57c637",
+		"legacySongID": 274,
+		"searchTerms": [],
+		"title": "Two Months Off"
+	},
+	{
+		"altTitles": [],
+		"artist": "こふ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554a26ffe61",
+		"legacySongID": 262,
+		"searchTerms": [],
+		"title": "Milkyway - memorable -"
+	},
+	{
+		"altTitles": [],
+		"artist": "SUi",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554a8114368",
+		"legacySongID": 266,
+		"searchTerms": [],
+		"title": "Planetarium"
+	},
+	{
+		"altTitles": [],
+		"artist": "Rephaim",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554a823c649",
+		"legacySongID": 252,
+		"searchTerms": [],
+		"title": "Lament Configuration"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nekomata Master feat. Mimi Nyami",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554b72613ce",
+		"legacySongID": 261,
+		"searchTerms": [],
+		"title": "TWINKLING"
+	},
+	{
+		"altTitles": [],
+		"artist": "Mr.Saturn",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554ccb0320e",
+		"legacySongID": 254,
+		"searchTerms": [],
+		"title": "Saturn"
+	},
+	{
+		"altTitles": [],
+		"artist": "Memme",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554e69463eb",
+		"legacySongID": 260,
+		"searchTerms": [],
+		"title": "Tantanmen"
+	},
+	{
+		"altTitles": [],
+		"artist": "工藤吉三（ベイシスケイプ）",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b554f2f5f2b3",
+		"legacySongID": 267,
+		"searchTerms": [],
+		"title": "キヤロラ衛星の軌跡"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJムラサメ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5550fe9181c",
+		"legacySongID": 278,
+		"searchTerms": [],
+		"title": "ANTHEM LANDING -A mix-"
+	},
+	{
+		"altTitles": [],
+		"artist": "HOUJIROU",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5551538db1f",
+		"legacySongID": 299,
+		"searchTerms": [],
+		"title": "Perfect Lady"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJムラサメ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55517cb6e91",
+		"legacySongID": 277,
+		"searchTerms": [],
+		"title": "ANTHEM LANDING -H mix-"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ryu☆",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5552b54e61c",
+		"legacySongID": 283,
+		"searchTerms": [],
+		"title": "竹取飛翔 ～ Lunatic Princess (Ryu☆Remix)"
+	},
+	{
+		"altTitles": [],
+		"artist": "Mr.T feat. KAFN",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555338a551b",
+		"legacySongID": 291,
+		"searchTerms": [],
+		"title": "Burning Heat! [2020 Re:build]"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nhato Vs. MK",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5553dab67e1",
+		"legacySongID": 300,
+		"searchTerms": [],
+		"title": "VIBRΛ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Anquette",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5553fec9225",
+		"legacySongID": 280,
+		"searchTerms": [],
+		"title": "MY BABY MAMA"
+	},
+	{
+		"altTitles": [],
+		"artist": "佐野電磁",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5554c3d78f3",
+		"legacySongID": 282,
+		"searchTerms": [],
+		"title": "Duration"
+	},
+	{
+		"altTitles": [],
+		"artist": "Team Grimoire",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55552ea857d",
+		"legacySongID": 279,
+		"searchTerms": [],
+		"title": "saQrifice"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nazzo-Non-Heat",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55561401176",
+		"legacySongID": 286,
+		"searchTerms": [],
+		"title": "Wandering Gravity"
+	},
+	{
+		"altTitles": [],
+		"artist": "D.watt (IOSYS)",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555702366ac",
+		"legacySongID": 288,
+		"searchTerms": [],
+		"title": "Underground Astronomy"
+	},
+	{
+		"altTitles": [],
+		"artist": "Jimmy Weckl feat.岩志太郎",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555842120f2",
+		"legacySongID": 296,
+		"searchTerms": [],
+		"title": "垂直OK!"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ryu*",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5558caf613e",
+		"legacySongID": 293,
+		"searchTerms": [],
+		"title": "in the Sky"
+	},
+	{
+		"altTitles": [],
+		"artist": "Zutt feat.NU-KO",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555998c019f",
+		"legacySongID": 298,
+		"searchTerms": [],
+		"title": "世界の果てに約束の凱歌を"
+	},
+	{
+		"altTitles": [],
+		"artist": "黒魔",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5559fe856b1",
+		"legacySongID": 292,
+		"searchTerms": [],
+		"title": "Sayonara Planet Wars"
+	},
+	{
+		"altTitles": [],
+		"artist": "山本真央樹",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555ad4c7526",
+		"legacySongID": 290,
+		"searchTerms": [],
+		"title": "Cosminflation"
+	},
+	{
+		"altTitles": [],
+		"artist": "THOMAS HOWARD",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555b0c0349e",
+		"legacySongID": 295,
+		"searchTerms": [],
+		"title": "Silent Hill"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJムラサメ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555b898eaaf",
+		"legacySongID": 276,
+		"searchTerms": [],
+		"title": "ANTHEM LANDING -N mix-"
+	},
+	{
+		"altTitles": [],
+		"artist": "庭師",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555c16202dc",
+		"legacySongID": 289,
+		"searchTerms": [],
+		"title": "solar systeM"
+	},
+	{
+		"altTitles": [],
+		"artist": "Dr.Honda",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555cc84429d",
+		"legacySongID": 281,
+		"searchTerms": [],
+		"title": "君のハートにロックオン"
+	},
+	{
+		"altTitles": [],
+		"artist": "Power Of Nature",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555cf9a251d",
+		"legacySongID": 275,
+		"searchTerms": [],
+		"title": "Hades Doll"
+	},
+	{
+		"altTitles": [],
+		"artist": "SDMS",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555de598c67",
+		"legacySongID": 285,
+		"searchTerms": [],
+		"title": "un deux trois"
+	},
+	{
+		"altTitles": [],
+		"artist": "asaki",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555de670a99",
+		"legacySongID": 294,
+		"searchTerms": [],
+		"title": "Stargazer"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ TOTTO",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555e76df56c",
+		"legacySongID": 287,
+		"searchTerms": [],
+		"title": "ビビットストリーム"
+	},
+	{
+		"altTitles": [],
+		"artist": "ニシジマユーキ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555edadfda8",
+		"legacySongID": 297,
+		"searchTerms": [],
+		"title": "Diffused Reflection"
+	},
+	{
+		"altTitles": [],
+		"artist": "TAG",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b555f007cc90",
+		"legacySongID": 284,
+		"searchTerms": [],
+		"title": "SABER WING"
+	},
+	{
+		"altTitles": [],
+		"artist": "原口沙輔 feat.重音テト",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55608428d09",
+		"legacySongID": 323,
+		"searchTerms": [],
+		"title": "イガク"
+	},
+	{
+		"altTitles": [],
+		"artist": "猫叉Master",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5560ebfa5d6",
+		"legacySongID": 311,
+		"searchTerms": [],
+		"title": "Nightmare before oversleep"
+	},
+	{
+		"altTitles": [],
+		"artist": "アリスシャッハと魔法の楽団",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5561a07002d",
+		"legacySongID": 324,
+		"searchTerms": [],
+		"title": "バッドエンド・シンドローム"
+	},
+	{
+		"altTitles": [],
+		"artist": "aran",
+		"data": {
+			"artistJP": "ｱﾗﾝ",
+			"displayVersion": "m+",
+			"titleJP": "ﾓｵﾝﾎﾞｳﾝﾂﾞ"
+		},
+		"id": "S19e3de7b5561f3833f2",
+		"legacySongID": 301,
+		"searchTerms": [],
+		"title": "Moonbound feat. Yukacco (USAO Remix)"
+	},
+	{
+		"altTitles": [],
+		"artist": "O2i3",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55620f2ef1a",
+		"legacySongID": 307,
+		"searchTerms": [],
+		"title": "Belly Flopper"
+	},
+	{
+		"altTitles": [],
+		"artist": "dj TAKA",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55623343764",
+		"legacySongID": 312,
+		"searchTerms": [],
+		"title": "Magical House Cleaning / Blue or Pink"
+	},
+	{
+		"altTitles": [],
+		"artist": "sasakure.UK feat. mirto",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55626bd4a5a",
+		"legacySongID": 305,
+		"searchTerms": [],
+		"title": "jet coaster☆girl tRiCkStAr Remix"
+	},
+	{
+		"altTitles": [],
+		"artist": "日向美ビタースイーツ♪",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b556377a7766",
+		"legacySongID": 316,
+		"searchTerms": [],
+		"title": "走れメロンパン"
+	},
+	{
+		"altTitles": [],
+		"artist": "ETIA.",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55655833141",
+		"legacySongID": 302,
+		"searchTerms": [],
+		"title": "Demetel"
+	},
+	{
+		"altTitles": [],
+		"artist": "PSYQUI",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55666fef487",
+		"legacySongID": 303,
+		"searchTerms": [],
+		"title": "MUTEKI"
+	},
+	{
+		"altTitles": [],
+		"artist": "日向美ビタースイーツ♪",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55667c17e9a",
+		"legacySongID": 319,
+		"searchTerms": [],
+		"title": "そこはかとなくロマンセ"
+	},
+	{
+		"altTitles": [],
+		"artist": "山本椛 (monotone)",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55672fafc97",
+		"legacySongID": 308,
+		"searchTerms": [],
+		"title": "突撃！ガラスのニーソ姫！"
+	},
+	{
+		"altTitles": [],
+		"artist": "日向美ビタースイーツ♪",
+		"data": {
+			"artistJP": "ﾋﾅﾀﾋﾞｰﾋﾞﾀｰｽｳｨｰﾂ",
+			"displayVersion": "m+",
+			"titleJP": "ｽｳｨｰﾂﾜｰﾄﾏｰﾗﾅｲ"
+		},
+		"id": "S19e3de7b556757a67b8",
+		"legacySongID": 317,
+		"searchTerms": [],
+		"title": "スイーツはとまらない♪"
+	},
+	{
+		"altTitles": [],
+		"artist": "Y2K, bbno$, Enrique Iglesias & Carly Rae Jepsen",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b556773cca85",
+		"legacySongID": 310,
+		"searchTerms": [],
+		"title": "Lalala Remix"
+	},
+	{
+		"altTitles": [],
+		"artist": "MasKaleido feat. ぁゅ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b556856c65c0",
+		"legacySongID": 306,
+		"searchTerms": [],
+		"title": "恋するレインガール"
+	},
+	{
+		"altTitles": [],
+		"artist": "日向美ビタースイーツ♪",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5568626025f",
+		"legacySongID": 315,
+		"searchTerms": [],
+		"title": "今夜はパジャマパーティ"
+	},
+	{
+		"altTitles": [],
+		"artist": "日向美ビタースイーツ♪",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b556864e3e8e",
+		"legacySongID": 320,
+		"searchTerms": [],
+		"title": "ホーンテッド★メイドランチ"
+	},
+	{
+		"altTitles": [],
+		"artist": "TAG underground overlay",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5568daf0fdc",
+		"legacySongID": 304,
+		"searchTerms": [],
+		"title": "Over The \"Period\""
+	},
+	{
+		"altTitles": [],
+		"artist": "Akira Complex",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5569a561f00",
+		"legacySongID": 321,
+		"searchTerms": [],
+		"title": "BLACK JACKAL"
+	},
+	{
+		"altTitles": [],
+		"artist": "Kanaria",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5569db21712",
+		"legacySongID": 322,
+		"searchTerms": [],
+		"title": "KING"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ YOSHITAKA",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b556a704043c",
+		"legacySongID": 314,
+		"searchTerms": [],
+		"title": "Lisa-RICCIA"
+	},
+	{
+		"altTitles": [],
+		"artist": "Blacklolita",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b556e53e327c",
+		"legacySongID": 313,
+		"searchTerms": [],
+		"title": "CyberConnect"
+	},
+	{
+		"altTitles": [],
+		"artist": "REDALiCE",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b556eb8af1b1",
+		"legacySongID": 309,
+		"searchTerms": [],
+		"title": "VEGA"
+	},
+	{
+		"altTitles": [],
+		"artist": "日向美ビタースイーツ♪",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b556f16623e7",
+		"legacySongID": 318,
+		"searchTerms": [],
+		"title": "滅びに至るエランプシス"
+	},
+	{
+		"altTitles": [],
+		"artist": "Mystic Moon",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557070c2526",
+		"legacySongID": 341,
+		"searchTerms": [],
+		"title": "IMANOGUILTS"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ako Atak",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557080a0fa5",
+		"legacySongID": 342,
+		"searchTerms": [],
+		"title": "BabeL ～Grand Story～"
+	},
+	{
+		"altTitles": [],
+		"artist": "AKIRA YAMAOKA",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5570f01a965",
+		"legacySongID": 328,
+		"searchTerms": [],
+		"title": "250bpm"
+	},
+	{
+		"altTitles": [],
+		"artist": "BEMANI Sound Team \"Mutsuhiko Izumi\"",
+		"data": {
+			"artistJP": "BEMANI Sound Team \"Mutsuhiko Izumi\"",
+			"displayVersion": "m+",
+			"titleJP": "MODEL FT4"
+		},
+		"id": "S19e3de7b55722974852",
+		"legacySongID": 325,
+		"searchTerms": [],
+		"title": "MODEL FT4"
+	},
+	{
+		"altTitles": [],
+		"artist": "SHAMDEL",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5573c421821",
+		"legacySongID": 350,
+		"searchTerms": [],
+		"title": "Towards the TOWER"
+	},
+	{
+		"altTitles": [],
+		"artist": "立秋 feat.ちょこ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5575827420c",
+		"legacySongID": 352,
+		"searchTerms": [],
+		"title": "竹"
+	},
+	{
+		"altTitles": [],
+		"artist": "Remixed by DJ Yoshitaka",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5578036c81e",
+		"legacySongID": 331,
+		"searchTerms": [],
+		"title": "GHOSTBUSTERS"
+	},
+	{
+		"altTitles": [],
+		"artist": "いよわ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5578870c0de",
+		"legacySongID": 330,
+		"searchTerms": [],
+		"title": "きゅうくらりん"
+	},
+	{
+		"altTitles": [],
+		"artist": "Power Of Nature",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5579eba8a33",
+		"legacySongID": 338,
+		"searchTerms": [],
+		"title": "少年は空を辿る"
+	},
+	{
+		"altTitles": [],
+		"artist": "庭師",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5579f868ec1",
+		"legacySongID": 347,
+		"searchTerms": [],
+		"title": "キュリオシティ"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ YOSHITAKA",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557a2c9ea99",
+		"legacySongID": 334,
+		"searchTerms": [],
+		"title": "Bloody Tears (IIDX EDITION)"
+	},
+	{
+		"altTitles": [],
+		"artist": "Power Of Nature",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557a76fc516",
+		"legacySongID": 343,
+		"searchTerms": [],
+		"title": "BabeL ～Next Story～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ARM feat. とろ美",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557aac1ca80",
+		"legacySongID": 326,
+		"searchTerms": [],
+		"title": "エンドレス・てゐマパーク"
+	},
+	{
+		"altTitles": [],
+		"artist": "seiya-murai feat.ALT",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557bb95cc20",
+		"legacySongID": 329,
+		"searchTerms": [],
+		"title": "隅田川夏恋歌"
+	},
+	{
+		"altTitles": [],
+		"artist": "Yukopi",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557cb50dd35",
+		"legacySongID": 327,
+		"searchTerms": [],
+		"title": "強風オールバック"
+	},
+	{
+		"altTitles": [],
+		"artist": "Dormir",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557cf5aa0ab",
+		"legacySongID": 336,
+		"searchTerms": [],
+		"title": "αρχη"
+	},
+	{
+		"altTitles": [],
+		"artist": "Cororo",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557d4825b54",
+		"legacySongID": 340,
+		"searchTerms": [],
+		"title": "ウエンレラの氷華"
+	},
+	{
+		"altTitles": [],
+		"artist": "Coyaan",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557db8a965f",
+		"legacySongID": 335,
+		"searchTerms": [],
+		"title": "Deep tenDon Reflex"
+	},
+	{
+		"altTitles": [],
+		"artist": "Camellia ft. Ninomae Ina'nis",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557e361da02",
+		"legacySongID": 333,
+		"searchTerms": [],
+		"title": "Drenched in Air"
+	},
+	{
+		"altTitles": [],
+		"artist": "Capital Wage Association",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557e44da743",
+		"legacySongID": 344,
+		"searchTerms": [],
+		"title": "BabeL ～roof garden～"
+	},
+	{
+		"altTitles": [],
+		"artist": "RedMuffleR",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557e9ad6756",
+		"legacySongID": 337,
+		"searchTerms": [],
+		"title": "Rubeus"
+	},
+	{
+		"altTitles": [],
+		"artist": "アメツチ絵日記",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557f3323505",
+		"legacySongID": 349,
+		"searchTerms": [],
+		"title": "黎明スケッチブック"
+	},
+	{
+		"altTitles": [],
+		"artist": "yuukiss",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b557f4669ba8",
+		"legacySongID": 332,
+		"searchTerms": [],
+		"title": "「月風魔伝」龍骨鬼戦 yks Remix"
+	},
+	{
+		"altTitles": [],
+		"artist": "fallen shepherd ft. RabbiTon Strings",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55800e6591a",
+		"legacySongID": 476,
+		"searchTerms": [],
+		"title": "ENDYMION"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ TOTTO",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55812bd0914",
+		"legacySongID": 354,
+		"searchTerms": [],
+		"title": "少女アリスと箱庭幻想コンチェルト"
+	},
+	{
+		"altTitles": [],
+		"artist": "Junior Senior",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55815a18884",
+		"legacySongID": 463,
+		"searchTerms": [],
+		"title": "Move Your Feet"
+	},
+	{
+		"altTitles": [],
+		"artist": "Hommarju",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55815be8ec6",
+		"legacySongID": 388,
+		"searchTerms": [],
+		"title": "Crazy Jackpot"
+	},
+	{
+		"altTitles": [],
+		"artist": "Endorfin.",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55815f04091",
+		"legacySongID": 394,
+		"searchTerms": [],
+		"title": "white night story"
+	},
+	{
+		"altTitles": [],
+		"artist": "REDALiCE",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55819b3a0b8",
+		"legacySongID": 368,
+		"searchTerms": [],
+		"title": "HiGHER"
+	},
+	{
+		"altTitles": [],
+		"artist": "佐々木博史",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558374b8b8f",
+		"legacySongID": 366,
+		"searchTerms": [],
+		"title": "Concertino In Blue"
+	},
+	{
+		"altTitles": [],
+		"artist": "C-Show",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5583ad77bbf",
+		"legacySongID": 374,
+		"searchTerms": [],
+		"title": "On the FM"
+	},
+	{
+		"altTitles": [],
+		"artist": "ああああ茶漬け",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558416b0dcb",
+		"legacySongID": 361,
+		"searchTerms": [],
+		"title": "魔女とオバケのいたずらファクトリー"
+	},
+	{
+		"altTitles": [],
+		"artist": "かめりあ feat. ななひら",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5585377c2c7",
+		"legacySongID": 373,
+		"searchTerms": [],
+		"title": "イーディーエム・ジャンパーズ ({E+H}DM Reboot)"
+	},
+	{
+		"altTitles": [],
+		"artist": "Mutsuhiko Izumi",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5585b0a558b",
+		"legacySongID": 557,
+		"searchTerms": [],
+		"title": "JET WORLD"
+	},
+	{
+		"altTitles": [],
+		"artist": "Qrispy Joybox",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5585d2c3bfd",
+		"legacySongID": 387,
+		"searchTerms": [],
+		"title": "snow prism"
+	},
+	{
+		"altTitles": [],
+		"artist": "Dirty Androids",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5585e4316cc",
+		"legacySongID": 365,
+		"searchTerms": [],
+		"title": "City Never Sleeps (IIDX Edition)"
+	},
+	{
+		"altTitles": [],
+		"artist": "Camellia",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55861002600",
+		"legacySongID": 364,
+		"searchTerms": [],
+		"title": "LOST TECHNOLOGIE"
+	},
+	{
+		"altTitles": [],
+		"artist": "m@sumi & kidlit",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55865bc305c",
+		"legacySongID": 395,
+		"searchTerms": [],
+		"title": "雪夜の森のプリャースカ"
+	},
+	{
+		"altTitles": [],
+		"artist": "John Robinson",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558687a0903",
+		"legacySongID": 462,
+		"searchTerms": [],
+		"title": "Kecak"
+	},
+	{
+		"altTitles": [],
+		"artist": "ぺのれり",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5586f39bebb",
+		"legacySongID": 358,
+		"searchTerms": [],
+		"title": "Preserved Valkyria"
+	},
+	{
+		"altTitles": [],
+		"artist": "Nhato",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55870fca583",
+		"legacySongID": 376,
+		"searchTerms": [],
+		"title": "Virus Funk"
+	},
+	{
+		"altTitles": [],
+		"artist": "M2U",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558737ae13c",
+		"legacySongID": 464,
+		"searchTerms": [],
+		"title": "PandorA"
+	},
+	{
+		"altTitles": [],
+		"artist": "CLUB SPICE",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55873e43297",
+		"legacySongID": 554,
+		"searchTerms": [],
+		"title": "CUTIE CHASER"
+	},
+	{
+		"altTitles": [],
+		"artist": "Auridy",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55876652c93",
+		"legacySongID": 384,
+		"searchTerms": [],
+		"title": "Dreaming Sweetness (SL mix)"
+	},
+	{
+		"altTitles": [],
+		"artist": "TAKA",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55880100e93",
+		"legacySongID": 392,
+		"searchTerms": [],
+		"title": "V2"
+	},
+	{
+		"altTitles": [],
+		"artist": "こふ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b55886985017",
+		"legacySongID": 386,
+		"searchTerms": [],
+		"title": "snow motion"
+	},
+	{
+		"altTitles": [],
+		"artist": "Ashley Tisdale",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b5588a17cdf5",
+		"legacySongID": 561,
+		"searchTerms": [],
+		"title": "He Said She Said"
+	},
+	{
+		"altTitles": [],
+		"artist": "Lapix",
+		"data": {
+			"artistJP": "ﾗﾋﾟｯｸｽ",
+			"displayVersion": "m+",
+			"titleJP": "ｳﾝﾀﾞ ﾒﾋﾞｭｽ"
+		},
+		"id": "S19e3de7b5589cc17df3",
+		"legacySongID": 579,
+		"searchTerms": [],
+		"title": "Under Mebius feat. 藍月なくる (YUKIYANAGI Remix)"
+	},
+	{
+		"altTitles": [],
+		"artist": "ke-ji",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558a2bc11ef",
+		"legacySongID": 359,
+		"searchTerms": [],
+		"title": "Joyeuse"
+	},
+	{
+		"altTitles": [],
+		"artist": "わるじぇんぬ",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558a739e7cb",
+		"legacySongID": 371,
+		"searchTerms": [],
+		"title": "O-HA! Mambo ~a Shiny new Today~"
+	},
+	{
+		"altTitles": [],
+		"artist": "TheaterR",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558b051a298",
+		"legacySongID": 360,
+		"searchTerms": [],
+		"title": "Ruins"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ ミラクル☆ストーン",
+		"data": {
+			"artistJP": "DJ Miracle☆Stone",
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558b61e3b5b",
+		"legacySongID": 543,
+		"searchTerms": [],
+		"title": "HAPPY☆LUCKY☆YEAPPY"
+	},
+	{
+		"altTitles": [],
+		"artist": "Noizenecio",
+		"data": {
+			"artistJP": "ﾉｲｾﾞﾈｼｵ",
+			"displayVersion": "m+",
+			"titleJP": "ﾗｲﾎﾞﾝ"
+		},
+		"id": "S19e3de7b558bc0e2ab6",
+		"legacySongID": 525,
+		"searchTerms": [],
+		"title": "Raibon"
+	},
+	{
+		"altTitles": [],
+		"artist": "camellia",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558d650a37f",
+		"legacySongID": 389,
+		"searchTerms": [],
+		"title": "Poison Mushroom"
+	},
+	{
+		"altTitles": [],
+		"artist": "SWAN K feat. Asuka M",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558f2969f66",
+		"legacySongID": 355,
+		"searchTerms": [],
+		"title": "Love B.B.B"
+	},
+	{
+		"altTitles": [],
+		"artist": "Maozon",
+		"data": {
+			"artistJP": null,
+			"displayVersion": "m+",
+			"titleJP": null
+		},
+		"id": "S19e3de7b558fdcb6e6f",
+		"legacySongID": 375,
+		"searchTerms": [],
+		"title": "Umbral"
 	}
 ]

--- a/db/seeds/tables.json
+++ b/db/seeds/tables.json
@@ -5676,6 +5676,33 @@
 		"title": "MÚSECA (1 + 1/2)"
 	},
 	{
+		"default": true,
+		"description": "Levels for MÚSECA in PLUS.",
+		"folders": [
+			"1-plus",
+			"2-plus",
+			"3-plus",
+			"4-plus",
+			"5-plus",
+			"6-plus",
+			"7-plus",
+			"8-plus",
+			"9-plus",
+			"10-plus",
+			"11-plus",
+			"12-plus",
+			"13-plus",
+			"14-plus",
+			"15-plus",
+			"16-plus"
+		],
+		"game": "museca",
+		"id": "T19e3e03e1370d162c9f",
+		"inactive": false,
+		"legacyTableID": "museca-Single-plus-levels",
+		"title": "MÚSECA (PLUS)"
+	},
+	{
 		"default": false,
 		"description": "Levels for O.N.G.E.K.I. in bright MEMORY Act.2 Omnimix.",
 		"folders": [

--- a/typescript/common/src/config/game-support/museca.ts
+++ b/typescript/common/src/config/game-support/museca.ts
@@ -99,6 +99,7 @@ export const GAME_MUSECA_CONF = {
 	versions: {
 		"1.5": "1 + 1/2",
 		"1.5-b": "1 + 1/2 Rev. B",
+		"m+": "PLUS",
 	},
 	/* eslint-enable quote-props */
 

--- a/typescript/seeds-scripts/rerunners/museca/add-latest-plus-db.js
+++ b/typescript/seeds-scripts/rerunners/museca/add-latest-plus-db.js
@@ -1,0 +1,101 @@
+// This imports the latest M+ database in the website's format
+// available from https:// m+ website /musicdb.json
+
+import { Command } from "commander";
+import fs from "fs";
+import crypto from "crypto";
+
+import { CreateSongID, CreateChartID, ReadCollection, WriteCollection } from "../../util.js";
+
+function Random20Hex() {
+	return crypto.randomBytes(20).toString("hex");
+}
+
+const PLUS_FIRST_SONG_ID = 227;
+const MUSECA_DIFFICULTIES = ["Green", "Yellow", "Red"];
+const B_REV_REMOVALS = [41, 42, 171];
+
+const program = new Command();
+program.option("-v, --vanilla", "Only import data from vanilla charts.", false);
+program.option("-d, --db <path to musicdb.json>", "The path to the M+ musicdb.json");
+program.parse(process.argv);
+const options = program.opts();
+
+const songs = ReadCollection("songs-museca.json");
+const charts = ReadCollection("charts-museca.json");
+
+const db = JSON.parse(fs.readFileSync(options.db));
+
+for (const music of db) {
+	// 1+1/2 songs start at 27th July 2016
+	// offline kit/b-rev exclusive songs have a date of 20th June 2018
+	// m+ songs start at a specific song ID
+	let version = "1";
+	if (music.id >= PLUS_FIRST_SONG_ID) version = "m+";
+	else if (music.distribution_date == 20180620) version = "1.5-b";
+	else if (music.distribution_date >= 20160727) version = "1.5";
+	// skip m+ songs if we're doing vanilla
+	if (options.vanilla && version == "m+") continue;
+
+	let existingSong = songs.find((song) => song.legacySongID === music.id);
+	const isNewSong = !existingSong;
+	if (isNewSong) {
+		// add the song to the db
+		songs.push({
+			altTitles: [],
+			data: {},
+			id: CreateSongID(),
+			legacySongID: music.id,
+			searchTerms: [],
+		});
+		existingSong = songs.find((song) => song.legacySongID === music.id);
+	}
+	// update the existing song in the db
+	existingSong.artist = music.artist;
+	existingSong.data.artistJP = music.artist_yomi;
+	existingSong.data.titleJP = music.title_yomi;
+	existingSong.data.displayVersion = version;
+	existingSong.title = music.title;
+
+	// get an array of versions this song is playable in
+	// version 1 isn't tracked by tachi so correct it to 1.5
+	let versions = [version == "1" ? "1.5" : version];
+	// if the song was in 1.5 and not removed in b rev then add b rev
+	if (versions[0] != "m+" && !B_REV_REMOVALS.includes(music.id)) versions.push("1.5-b");
+	// all songs are playable in m+
+	if (!options.vanilla && !versions.includes("m+")) versions.push("m+");
+
+	// iterate through the charts
+	for (let i = 0; i < 3; i++) {
+		const diff = MUSECA_DIFFICULTIES[i];
+		let existingChart = charts.find(
+			(charts) => charts.songID === existingSong.id && charts.difficulty == diff,
+		);
+		const isNewChart = !existingChart;
+		if (isNewChart) {
+			// add the chart to the db
+			charts.push({
+				data: {
+					inGameID: music.id,
+				},
+				difficulty: diff,
+				id: CreateChartID(),
+				isPrimary: true,
+				songID: existingSong.id,
+				legacyChartID: Random20Hex(),
+				versions,
+			});
+			existingChart = charts.find(
+				(charts) => charts.songID === existingSong.id && charts.difficulty == diff,
+			);
+		}
+		// edit the existing chart
+		existingChart.versions = versions;
+		existingChart.level = music.cskill_levels[i].toString();
+		existingChart.levelNum = music.cskill_levels[i];
+		existingChart.data.inGameID = music.id;
+	}
+}
+
+WriteCollection("songs-museca.json", songs);
+WriteCollection("charts-museca.json", charts);


### PR DESCRIPTION
This adds support for the M+ mod for MÚSECA as well as updates and corrects previous seed data for 1+1/2 using the music DB JSON file offered on the M+ website, with a script added for updating based on that music DB.

Songs have their level based on the level that the game uses internally to calculate your curator skill, not the one displayed in-game; M+'s additional level 16s are marked as level 15s for this reason. (Maybe I should add these to the M+ Lv. 16 folder?)

---

Before this is merged I'd also like to propose the removal of the 1+1/2 Rev. B "version" for MÚSECA - the only difference is 3 songs being removed from the DB (these songs were missing in the previous Tachi seeds anyway, making it incorrect) and 3 new songs being added that are also present in 1+1/2's game files (again, 2 of these were missing in Tachi's previous seeds), all of these songs often being enabled by servers across both specs.