### PR TITLE
seeds: correct museca data

### DIFF
--- a/db/seeds/charts-museca.json
+++ b/db/seeds/charts-museca.json
@@ -439,7 +439,7 @@
 		"level": "3",
 		"levelNum": 3,
 		"songID": "S19d35e0b42f6d1ef0bb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b"]
 	},
 	{
 		"data": {
@@ -452,7 +452,7 @@
 		"level": "12",
 		"levelNum": 12,
 		"songID": "S19d35e0b42f6d1ef0bb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b"]
 	},
 	{
 		"data": {
@@ -465,7 +465,7 @@
 		"level": "9",
 		"levelNum": 9,
 		"songID": "S19d35e0b42f6d1ef0bb",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b"]
 	},
 	{
 		"data": {
@@ -634,7 +634,7 @@
 		"level": "5",
 		"levelNum": 5,
 		"songID": "S19d35e0b4348d400e96",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b"]
 	},
 	{
 		"data": {
@@ -647,7 +647,7 @@
 		"level": "13",
 		"levelNum": 13,
 		"songID": "S19d35e0b4348d400e96",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b"]
 	},
 	{
 		"data": {
@@ -660,7 +660,7 @@
 		"level": "11",
 		"levelNum": 11,
 		"songID": "S19d35e0b4348d400e96",
-		"versions": ["1.5", "1.5-b"]
+		"versions": ["1.5-b"]
 	},
 	{
 		"data": {
@@ -7954,5 +7954,122 @@
 		"levelNum": 12,
 		"songID": "S19d35e0b506c6a58ca7",
 		"versions": ["1.5-b"]
+	},
+	{
+		"data": {
+			"inGameID": 42
+		},
+		"difficulty": "Green",
+		"id": "C19e41e45a8c013a42f8",
+		"isPrimary": true,
+		"legacyChartID": "a27c48fa9314579a14ee4f3808f7c48f30e10963",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e41e45a8cdc32ab33",
+		"versions": ["1.5"]
+	},
+	{
+		"data": {
+			"inGameID": 42
+		},
+		"difficulty": "Red",
+		"id": "C19e41e45a8c062f6d51",
+		"isPrimary": true,
+		"legacyChartID": "c3a1882c36b658096021b3050be2e77c3139f435",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19e41e45a8cdc32ab33",
+		"versions": ["1.5"]
+	},
+	{
+		"data": {
+			"inGameID": 42
+		},
+		"difficulty": "Yellow",
+		"id": "C19e41e45a8ccf1a01b1",
+		"isPrimary": true,
+		"legacyChartID": "3a6607b874260656d1dd5354879421994701e8c0",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e41e45a8cdc32ab33",
+		"versions": ["1.5"]
+	},
+	{
+		"data": {
+			"inGameID": 41
+		},
+		"difficulty": "Green",
+		"id": "C19e41e45a8c5676b16d",
+		"isPrimary": true,
+		"legacyChartID": "b56c0063cd9ddc6075f2c437409cd2808c168bc9",
+		"level": "2",
+		"levelNum": 2,
+		"songID": "S19e41e45a8cf93f46cf",
+		"versions": ["1.5"]
+	},
+	{
+		"data": {
+			"inGameID": 41
+		},
+		"difficulty": "Red",
+		"id": "C19e41e45a8ce12dda29",
+		"isPrimary": true,
+		"legacyChartID": "4f0cc7c7dc2156b1712cc48d425a18e495a3dd83",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19e41e45a8cf93f46cf",
+		"versions": ["1.5"]
+	},
+	{
+		"data": {
+			"inGameID": 41
+		},
+		"difficulty": "Yellow",
+		"id": "C19e41e45a8cb0388326",
+		"isPrimary": true,
+		"legacyChartID": "34d8187369bbb03f26c223d43df779c7204d9a38",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19e41e45a8cf93f46cf",
+		"versions": ["1.5"]
+	},
+	{
+		"data": {
+			"inGameID": 171
+		},
+		"difficulty": "Green",
+		"id": "C19e41e45a8e0c4b9da4",
+		"isPrimary": true,
+		"legacyChartID": "7447b69d9ebe21ea77d2981117ab6d07dc9f189d",
+		"level": "3",
+		"levelNum": 3,
+		"songID": "S19e41e45a8eb33ddbcf",
+		"versions": ["1.5"]
+	},
+	{
+		"data": {
+			"inGameID": 171
+		},
+		"difficulty": "Red",
+		"id": "C19e41e45a8efbb43004",
+		"isPrimary": true,
+		"legacyChartID": "da08d1063b82a59ced8e8c6e990339a14c306444",
+		"level": "14",
+		"levelNum": 14,
+		"songID": "S19e41e45a8eb33ddbcf",
+		"versions": ["1.5"]
+	},
+	{
+		"data": {
+			"inGameID": 171
+		},
+		"difficulty": "Yellow",
+		"id": "C19e41e45a8e6c21064d",
+		"isPrimary": true,
+		"legacyChartID": "72f4457e382d81b369667cc0d427ac9988899c86",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19e41e45a8eb33ddbcf",
+		"versions": ["1.5"]
 	}
 ]

--- a/db/seeds/songs-museca.json
+++ b/db/seeds/songs-museca.json
@@ -1,7 +1,7 @@
 [
 	{
 		"altTitles": [],
-		"artist": "Last Note. feat. GUMI",
+		"artist": "Last Note． feat. GUMI",
 		"data": {
 			"artistJP": "ﾗｽﾄﾉｰﾄﾌｨｰﾁｬﾘﾝｸﾞｸﾞﾐ",
 			"displayVersion": "1",
@@ -147,7 +147,7 @@
 		"artist": "Music by MasKaleido, Vocal by ぁゅ",
 		"data": {
 			"artistJP": "ﾏｽｶﾚｲﾄﾞ",
-			"displayVersion": "1",
+			"displayVersion": "1.5-b",
 			"titleJP": "ｽﾀｰﾀﾞｽﾄﾏｰﾒｲﾄﾞ"
 		},
 		"id": "S19d35e0b42f6d1ef0bb",
@@ -212,7 +212,7 @@
 		"artist": "millstones",
 		"data": {
 			"artistJP": "ﾐﾙｽﾄｰﾝｽﾞ",
-			"displayVersion": "1",
+			"displayVersion": "1.5-b",
 			"titleJP": "ﾄﾏﾄﾘｰﾌﾌﾞﾚｲｸｽ"
 		},
 		"id": "S19d35e0b4348d400e96",
@@ -224,9 +224,9 @@
 		"altTitles": [],
 		"artist": "VALLEYSTONE feat. 紫崎 雪",
 		"data": {
-			"artistJP": "ﾊﾞﾘｰｽﾄｰﾝ ﾋｭｰﾁｬﾘﾝｸﾞ ｼｻﾞｷﾕｷ",
+			"artistJP": "ﾊﾞﾘｰｽﾄｰﾝﾋｭｰﾁｬﾘﾝｸﾞｼｻﾞｷﾕｷ",
 			"displayVersion": "1",
-			"titleJP": "ﾗﾌﾞｼｯｸ ﾗﾌﾞﾁｭｰﾝ"
+			"titleJP": "ﾗﾌﾞｼｯｸﾗﾌﾞﾁｭｰﾝ"
 		},
 		"id": "S19d35e0b435a966cff4",
 		"legacySongID": 18,
@@ -278,7 +278,7 @@
 		"data": {
 			"artistJP": "ｸﾛﾏ",
 			"displayVersion": "1",
-			"titleJP": "ﾎﾟﾝﾎﾟﾝﾎﾟﾝﾎﾟｺﾀﾞｲｾﾝｿｳ!"
+			"titleJP": "ﾎﾟﾝﾎﾟﾝﾎﾟﾝﾎﾟｺﾀﾞｲｾﾝｿｳ"
 		},
 		"id": "S19d35e0b439c7c2ca64",
 		"legacySongID": 22,
@@ -368,7 +368,7 @@
 		"artist": "C-Show",
 		"data": {
 			"artistJP": "ｼｼｮｳ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾕｰｴﾇｵｰｴﾝﾜｶﾉｼﾞｮﾅﾉｶﾄｰﾎﾘｯｸﾐｯｸｽ"
 		},
 		"id": "S19d35e0b4408cf2f105",
@@ -413,7 +413,7 @@
 		"id": "S19d35e0b44440c9f6eb",
 		"legacySongID": 33,
 		"searchTerms": [],
-		"title": "inverted RAINBOW (M齣SECA Ver.)"
+		"title": "inverted RAINBOW (MÚSECA Ver.)"
 	},
 	{
 		"altTitles": [],
@@ -433,7 +433,7 @@
 		"artist": "埼玉最終兵器",
 		"data": {
 			"artistJP": "ｻｲﾀﾏｻｲｼｭｳﾍｲｷ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾃﾝｸｳﾉﾊﾅﾉﾐﾔｺ"
 		},
 		"id": "S19d35e0b44658211805",
@@ -446,7 +446,7 @@
 		"artist": "XL Project -yanagizm side-",
 		"data": {
 			"artistJP": "ｴｸｾﾙﾌﾟﾛｼﾞｪｸﾄﾔﾅｷﾞｽﾞﾑｻｲﾄﾞ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾎｵｽﾞｷﾐﾀｲﾆｱｶｲﾀﾏｼｲｼﾞｮｳﾈﾂｽﾀｲﾙ"
 		},
 		"id": "S19d35e0b448ca11f6d5",
@@ -459,7 +459,7 @@
 		"artist": "アゴアニキ",
 		"data": {
 			"artistJP": "ｱｺﾞｱﾆｷ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾀﾞﾌﾞﾙﾗﾘｱｯﾄ"
 		},
 		"id": "S19d35e0b4491f73dd42",
@@ -498,7 +498,7 @@
 		"artist": "まふまふ",
 		"data": {
 			"artistJP": "ﾏﾌﾏﾌ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾊｰﾄﾉｱﾄｱｼﾞ"
 		},
 		"id": "S19d35e0b45165912643",
@@ -846,7 +846,7 @@
 	},
 	{
 		"altTitles": [],
-		"artist": "溝口ゆうま feat. みこ齶なち齶あい",
+		"artist": "溝口ゆうま feat. みこ♡なち♡あい",
 		"data": {
 			"artistJP": "ﾐｿﾞﾉｸﾁﾕｳﾏﾌｭｰﾁｬﾘﾝｸﾞﾐｺﾅﾁｱｲ",
 			"displayVersion": "1",
@@ -859,7 +859,7 @@
 	},
 	{
 		"altTitles": [],
-		"artist": "miko齶nachi feat.u-z",
+		"artist": "miko♡nachi feat.u-z",
 		"data": {
 			"artistJP": "ﾐｺﾊｰﾄﾅﾁﾌｨｰﾁｬﾘﾝｸﾞﾕｰｼﾞ",
 			"displayVersion": "1",
@@ -1089,7 +1089,7 @@
 		"id": "S19d35e0b47f5beefa69",
 		"legacySongID": 92,
 		"searchTerms": [],
-		"title": "齧rche"
+		"title": "Ärche"
 	},
 	{
 		"altTitles": [],
@@ -1187,7 +1187,7 @@
 		"artist": "Nem",
 		"data": {
 			"artistJP": "ﾈﾑ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ｱｱｽﾊﾞﾗｼｷﾆｬﾝｾｲ"
 		},
 		"id": "S19d35e0b488cde6f260",
@@ -1200,7 +1200,7 @@
 		"artist": "トーマ",
 		"data": {
 			"artistJP": "ﾄｰﾏ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾏﾎｳｼｮｳｼﾞｮｺｳﾌｸﾛﾝ"
 		},
 		"id": "S19d35e0b48a215882c2",
@@ -1213,7 +1213,7 @@
 		"artist": "M.S.S Project",
 		"data": {
 			"artistJP": "ｴﾑｴｽｴｽﾌﾟﾛｼﾞｪｸﾄ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ｴﾑｴｽｴｽﾌﾟﾗﾈｯﾄ"
 		},
 		"id": "S19d35e0b48bc9b3561d",
@@ -1239,7 +1239,7 @@
 		"artist": "n.k",
 		"data": {
 			"artistJP": "ｴﾇｹｰ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ｺﾉﾌｻﾞｹﾀｽﾊﾞﾗｼｷｾｶｲﾊ､ﾎﾞｸﾉﾀﾒﾆｱﾙ"
 		},
 		"id": "S19d35e0b48eed08c590",
@@ -1252,7 +1252,7 @@
 		"artist": "n-buna",
 		"data": {
 			"artistJP": "ﾅﾌﾞﾅ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾑｼﾞﾝｴｷ"
 		},
 		"id": "S19d35e0b48fab7c3dfa",
@@ -1278,7 +1278,7 @@
 		"artist": "Pa's Lam System",
 		"data": {
 			"artistJP": "ﾊﾟｽﾞﾗﾑｼｽﾃﾑ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ｲﾌ"
 		},
 		"id": "S19d35e0b4912dffb3b9",
@@ -1291,7 +1291,7 @@
 		"artist": "Yu_Asahina",
 		"data": {
 			"artistJP": "ﾕｳｱｻﾋﾅ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾌｧﾝｸｼｮﾝﾅﾝﾊﾞｰﾌｧｲﾌﾞ"
 		},
 		"id": "S19d35e0b492bcaa581a",
@@ -1304,7 +1304,7 @@
 		"artist": "Yunomi",
 		"data": {
 			"artistJP": "ﾕﾉﾐ",
-			"displayVersion": "1",
+			"displayVersion": "1.5",
 			"titleJP": "ﾐﾀﾗｼﾌﾟﾗﾄﾆｯｸﾌｨｰﾁｬﾘﾝｸﾞﾆｶﾓｷｭ"
 		},
 		"id": "S19d35e0b49326eb55c9",
@@ -1707,7 +1707,7 @@
 		"artist": "Daisuke Ohnuma",
 		"data": {
 			"artistJP": "ﾀﾞｲｽｹｵｵﾇﾏ",
-			"displayVersion": "15",
+			"displayVersion": "1.5",
 			"titleJP": "ｸﾗｯｸﾕｱｿｳﾙ"
 		},
 		"id": "S19d35e0b4b942b6dde2",
@@ -2643,12 +2643,51 @@
 		"artist": "ぺのれり",
 		"data": {
 			"artistJP": "ﾍﾟﾉﾚﾘ",
-			"displayVersion": "1.5",
+			"displayVersion": "1.5-b",
 			"titleJP": "ｴｳﾞｧｰﾗｽﾃｨﾝｸﾞﾒｯｾｰｼﾞ"
 		},
 		"id": "S19d35e0b506c6a58ca7",
 		"legacySongID": 226,
 		"searchTerms": [],
 		"title": "Everlasting Message"
+	},
+	{
+		"altTitles": [],
+		"artist": "ハチ",
+		"data": {
+			"artistJP": "ﾊﾁ",
+			"displayVersion": "1.5",
+			"titleJP": "ﾄﾞｰﾅﾂﾎｰﾙ"
+		},
+		"id": "S19e41e45a8cdc32ab33",
+		"legacySongID": 42,
+		"searchTerms": [],
+		"title": "ドーナツホール"
+	},
+	{
+		"altTitles": [],
+		"artist": "ハチ",
+		"data": {
+			"artistJP": "ﾊﾁ",
+			"displayVersion": "1.5",
+			"titleJP": "ﾏﾄﾘｮｼｶ"
+		},
+		"id": "S19e41e45a8cf93f46cf",
+		"legacySongID": 41,
+		"searchTerms": [],
+		"title": "マトリョシカ"
+	},
+	{
+		"altTitles": [],
+		"artist": "ノマ",
+		"data": {
+			"artistJP": "ﾉﾏ",
+			"displayVersion": "1.5",
+			"titleJP": "ﾌﾞﾚｲﾝﾊﾟﾜｰ"
+		},
+		"id": "S19e41e45a8eb33ddbcf",
+		"legacySongID": 171,
+		"searchTerms": [],
+		"title": "Brain Power"
 	}
 ]


### PR DESCRIPTION
Corrects displayVersion for MUSECA charts, fixes Rev. B songs showing up in non-Rev B. folders and adds the missing removed 1+1/2 songs (Brain Power etc.)