### PR TITLE
feat: folder goal exemptions for metrics with chartDependentMax

### DIFF
--- a/typescript/common/src/config/config.ts
+++ b/typescript/common/src/config/config.ts
@@ -355,7 +355,7 @@ export function ValidateMetric(gameConfig: GameConfig, metricName: string, metri
 		return "Cannot validate a graph or nullable graph metric.";
 	}
 
-	if (conf.chartDependentMax) {
+	if (conf.chartDependentMax === true) {
 		return `This metric is chart dependent and not appropriate to check in this context.`;
 	}
 

--- a/typescript/common/src/config/game-support/arcaea.ts
+++ b/typescript/common/src/config/game-support/arcaea.ts
@@ -1,3 +1,4 @@
+import { p } from "prudence";
 import { z } from "zod";
 
 import type { INTERNAL_GAME_CONFIG, INTERNAL_GAME_GROUP_CONFIG } from "../../types/internals";
@@ -47,7 +48,8 @@ export const GAME_ARCAEA_CONF = {
 	providedMetrics: {
 		score: {
 			type: "INTEGER",
-			chartDependentMax: true,
+			chartDependentMax: (v: number) => v >= 10_000_000,
+			validate: p.isPositiveInteger,
 			formatter: FmtNum,
 			description:
 				"The score value. This is between 0 and 10 million, plus bonus points dependent on how many shiny PUREs you get.",

--- a/typescript/common/src/config/game-support/arcaea.ts
+++ b/typescript/common/src/config/game-support/arcaea.ts
@@ -48,8 +48,9 @@ export const GAME_ARCAEA_CONF = {
 	providedMetrics: {
 		score: {
 			type: "INTEGER",
-			chartDependentMax: (v: number) => v >= 10_000_000,
+			chartDependentMax: true,
 			validate: p.isPositiveInteger,
+			allowFolderGoalsIf: (v: number) => v < 10_000_000,
 			formatter: FmtNum,
 			description:
 				"The score value. This is between 0 and 10 million, plus bonus points dependent on how many shiny PUREs you get.",

--- a/typescript/common/src/config/game-support/maimai.ts
+++ b/typescript/common/src/config/game-support/maimai.ts
@@ -1,3 +1,4 @@
+import { p } from "prudence";
 import { z } from "zod";
 
 import type { INTERNAL_GAME_CONFIG, INTERNAL_GAME_GROUP_CONFIG } from "../../types/internals";
@@ -62,6 +63,8 @@ export const GAME_MAIMAI_CONF = {
 		percent: {
 			type: "DECIMAL",
 			chartDependentMax: true,
+			allowFolderGoalsIf: (v) => v >= 0 && v < 100.0,
+			validate: p.isPositive,
 			formatter: FmtPercent,
 			description:
 				"The percent this score was worth. Sometimes called 'rate' in game. This is upper-bounded by how many BREAK notes the chart has.",

--- a/typescript/common/src/types/metrics.ts
+++ b/typescript/common/src/types/metrics.ts
@@ -59,12 +59,44 @@ interface ConfIntegerScoreMetricChartDependent {
 	chartDependentMax: true;
 }
 
+interface ConfDecimalScoreMetricConditionallyChartDependent {
+	type: "DECIMAL";
+	formatter: (v: number) => string;
+	validate: (v: number) => string | true;
+
+	/**
+	 * Is the maximum/minimum value of this metric chart dependent?
+	 *
+	 * @example:
+	 * Arcaea's score is upperbounded at 10M+notecount, but scores below 10M
+	 * behave as if the max was 10M.
+	 */
+	chartDependentMax: (v: number) => boolean;
+}
+
+interface ConfIntegerScoreMetricConditionallyChartDependent {
+	type: "INTEGER";
+	formatter: (v: number) => string;
+	validate: (v: number) => string | true;
+
+	/**
+	 * Is the maximum/minimum value of this metric chart dependent?
+	 *
+	 * @example:
+	 * Arcaea's score is upperbounded at 10M+notecount, but scores below 10M
+	 * behave as if the max was 10M.
+	 */
+	chartDependentMax: (v: number) => boolean;
+}
+
 export type ConfDecimalScoreMetric =
 	| ConfDecimalScoreMetricChartDependent
+	| ConfDecimalScoreMetricConditionallyChartDependent
 	| ConfDecimalScoreMetricNormal;
 
 export type ConfIntegerScoreMetric =
 	| ConfIntegerScoreMetricChartDependent
+	| ConfIntegerScoreMetricConditionallyChartDependent
 	| ConfIntegerScoreMetricNormal;
 
 /**

--- a/typescript/common/src/types/metrics.ts
+++ b/typescript/common/src/types/metrics.ts
@@ -45,6 +45,7 @@ interface ConfDecimalScoreMetricChartDependent {
 	 * @example: IIDX's EX Score is upperbounded at 2x the chart's notecount.
 	 */
 	chartDependentMax: true;
+	allowFolderGoalsIf?: never;
 }
 
 interface ConfIntegerScoreMetricChartDependent {
@@ -57,46 +58,51 @@ interface ConfIntegerScoreMetricChartDependent {
 	 * @example: IIDX's EX Score is upperbounded at 2x the chart's notecount.
 	 */
 	chartDependentMax: true;
+	allowFolderGoalsIf?: never;
 }
 
-interface ConfDecimalScoreMetricConditionallyChartDependent {
+interface ConfDecimalScoreMetricChartDependentWithExemption {
 	type: "DECIMAL";
 	formatter: (v: number) => string;
 	validate: (v: number) => string | true;
 
 	/**
-	 * Is the maximum/minimum value of this metric chart dependent?
+	 * When the value is chart dependent,
+	 * should folder-wide goals be allowed conditionally?
 	 *
 	 * @example:
 	 * Arcaea's score is upperbounded at 10M+notecount, but scores below 10M
 	 * behave as if the max was 10M.
 	 */
-	chartDependentMax: (v: number) => boolean;
+	allowFolderGoalsIf: (v: number) => boolean;
+	chartDependentMax: true;
 }
 
-interface ConfIntegerScoreMetricConditionallyChartDependent {
+interface ConfIntegerScoreMetricChartDependentWithExemption {
 	type: "INTEGER";
 	formatter: (v: number) => string;
 	validate: (v: number) => string | true;
 
 	/**
-	 * Is the maximum/minimum value of this metric chart dependent?
+	 * When the value is chart dependent,
+	 * should folder-wide goals be allowed conditionally?
 	 *
 	 * @example:
 	 * Arcaea's score is upperbounded at 10M+notecount, but scores below 10M
 	 * behave as if the max was 10M.
 	 */
-	chartDependentMax: (v: number) => boolean;
+	allowFolderGoalsIf: (v: number) => boolean;
+	chartDependentMax: true;
 }
 
 export type ConfDecimalScoreMetric =
 	| ConfDecimalScoreMetricChartDependent
-	| ConfDecimalScoreMetricConditionallyChartDependent
+	| ConfDecimalScoreMetricChartDependentWithExemption
 	| ConfDecimalScoreMetricNormal;
 
 export type ConfIntegerScoreMetric =
 	| ConfIntegerScoreMetricChartDependent
-	| ConfIntegerScoreMetricConditionallyChartDependent
+	| ConfIntegerScoreMetricChartDependentWithExemption
 	| ConfIntegerScoreMetricNormal;
 
 /**

--- a/typescript/server/src/game-implementations/types.ts
+++ b/typescript/server/src/game-implementations/types.ts
@@ -28,7 +28,7 @@ export type ChartSpecificMetricValidator<TGame extends V3Game> = (
 ) => string | true;
 
 interface ChartDependentMax {
-	chartDependentMax: true;
+	chartDependentMax: ((v: number) => boolean) | true;
 }
 
 export type SessionCalculator<TGame extends V3Game> = (

--- a/typescript/server/src/game-implementations/types.ts
+++ b/typescript/server/src/game-implementations/types.ts
@@ -28,7 +28,7 @@ export type ChartSpecificMetricValidator<TGame extends V3Game> = (
 ) => string | true;
 
 interface ChartDependentMax {
-	chartDependentMax: ((v: number) => boolean) | true;
+	chartDependentMax: true;
 }
 
 export type SessionCalculator<TGame extends V3Game> = (

--- a/typescript/server/src/lib/targets/goal-utils.ts
+++ b/typescript/server/src/lib/targets/goal-utils.ts
@@ -265,7 +265,9 @@ export async function ValidateGoalChartsAndCriteria(
 	switch (config.type) {
 		case "DECIMAL":
 		case "INTEGER": {
-			if (config.chartDependentMax && charts.type !== "single") {
+			const chartDependentMax =
+				config.chartDependentMax === true || config.chartDependentMax?.(criteria.value);
+			if (chartDependentMax && charts.type !== "single") {
 				throw new Error(
 					`Creating ${criteria.key} goals on multiple charts where the maximum value is relative to the chart is a terrible idea, and has been disabled.`,
 				);
@@ -273,7 +275,7 @@ export async function ValidateGoalChartsAndCriteria(
 
 			let err;
 
-			if (config.chartDependentMax) {
+			if (chartDependentMax) {
 				const chart = await GetChartByIdForGame(game, charts.data as string);
 
 				if (!chart) {

--- a/typescript/server/src/lib/targets/goal-utils.ts
+++ b/typescript/server/src/lib/targets/goal-utils.ts
@@ -265,9 +265,9 @@ export async function ValidateGoalChartsAndCriteria(
 	switch (config.type) {
 		case "DECIMAL":
 		case "INTEGER": {
-			const chartDependentMax =
-				config.chartDependentMax === true || config.chartDependentMax?.(criteria.value);
-			if (chartDependentMax && charts.type !== "single") {
+			const allowFolderGoals = config.chartDependentMax !== true || config.allowFolderGoalsIf?.(criteria.value);
+
+			if (!allowFolderGoals && charts.type !== "single") {
 				throw new Error(
 					`Creating ${criteria.key} goals on multiple charts where the maximum value is relative to the chart is a terrible idea, and has been disabled.`,
 				);
@@ -275,7 +275,7 @@ export async function ValidateGoalChartsAndCriteria(
 
 			let err;
 
-			if (chartDependentMax) {
+			if (!allowFolderGoals) {
 				const chart = await GetChartByIdForGame(game, charts.data as string);
 
 				if (!chart) {
@@ -287,6 +287,7 @@ export async function ValidateGoalChartsAndCriteria(
 				// @ts-expect-error this is fine leave me alone
 				err = gptImpl.chartSpecificValidators[criteria.key](criteria.value, chart);
 			} else {
+				// @ts-expect-error if allowFolderGoals is true, validate has to exist, and tsc's opinion has no weight here.
 				err = config.validate(criteria.value);
 			}
 

--- a/typescript/server/src/lib/targets/goal-utils.ts
+++ b/typescript/server/src/lib/targets/goal-utils.ts
@@ -265,7 +265,8 @@ export async function ValidateGoalChartsAndCriteria(
 	switch (config.type) {
 		case "DECIMAL":
 		case "INTEGER": {
-			const allowFolderGoals = config.chartDependentMax !== true || config.allowFolderGoalsIf?.(criteria.value);
+			const allowFolderGoals =
+				config.chartDependentMax !== true || config.allowFolderGoalsIf?.(criteria.value);
 
 			if (!allowFolderGoals && charts.type !== "single") {
 				throw new Error(


### PR DESCRIPTION
Really dumb hack, but in my defense, the hard split between `impl.chartSpecificValidators` and `conf.validate` based on `chartDependentMax` is also really odd.

Arcaea has a well regarded scoring system where GREAT=100% and PGREAT=100%+1. And 100% is 10 Million. This means that if a chart has 1000 notes, a perfect score can be between 10,000,000 and 10,001,000. Therefore, `score` is `chartDependentMax`, because it is–and it wouldn't make sense to set a folder goal for >10,001,000 for the same reason it wouldn't make sense to have a goal of 3000 in IIDX. But non-perfect scores behave more like in MÚSECA because the difference between CRITICAL and S-CRITICAL (on a hypothetical 120Hz MÚSECA cab) becomes insignificant, and there is definitely an incentive to set folder goals such as 9,700,000 especially with Arcaea only having 2 relevant score grades (9.8M and 9.9M). 