### PR TITLE
fix: arcaea notecount check

### DIFF
--- a/typescript/server/src/game-implementations/games/arcaea.test.ts
+++ b/typescript/server/src/game-implementations/games/arcaea.test.ts
@@ -410,6 +410,16 @@ describe("ARCAEA_IMPL", () => {
 					},
 				),
 			).toBeUndefined();
+
+			expect(
+				runVal({
+					scoreData: {
+						lamp: "CLEAR",
+						score: 9_970_000,
+						judgements: {},
+					},
+				}),
+			).toBeUndefined();
 		});
 	});
 });

--- a/typescript/server/src/game-implementations/games/arcaea.test.ts
+++ b/typescript/server/src/game-implementations/games/arcaea.test.ts
@@ -352,5 +352,39 @@ describe("ARCAEA_IMPL", () => {
 				}),
 			).toBeUndefined();
 		});
+
+		it("rejects impossibly large number of judgements", () => {
+			expect(
+				runVal({
+					scoreData: {
+						lamp: "CLEAR",
+						score: 9_970_000,
+						judgements: { pure: 1150, far: 20, lost: 10 },
+					},
+				}),
+			).toEqual([
+				`Too many judgements: received ${1180} in total but the chart's note count is ${1151}.`,
+			]);
+
+			expect(
+				runVal({
+					scoreData: {
+						lamp: "CLEAR",
+						score: 9_970_000,
+						judgements: { pure: 1121, far: 20, lost: 10 },
+					},
+				}),
+			).toBeUndefined();
+
+			expect(
+				runVal({
+					scoreData: {
+						lamp: "CLEAR",
+						score: 9_970_000,
+						judgements: { pure: 1120, far: 20, lost: 10 },
+					},
+				}),
+			).toBeUndefined();
+		});
 	});
 });

--- a/typescript/server/src/game-implementations/games/arcaea.test.ts
+++ b/typescript/server/src/game-implementations/games/arcaea.test.ts
@@ -17,6 +17,7 @@ import { UnixMillisecondsToISO8601 } from "#utils/time";
 import {
 	ARCAEA_GRADES,
 	ARCAEA_LAMPS,
+	type ChartDocument,
 	type MongoProvidedMetrics,
 	type ScoreData,
 	type ScoreDocument,
@@ -234,8 +235,15 @@ describe("ARCAEA_IMPL", () => {
 	describe("scoreValidators & chartSpecificValidators", () => {
 		const mockScore = mkMockScore("arcaea", chart, scoreData);
 
-		const runVal = (s: DeepPartial<ScoreDocument<"arcaea">>) =>
-			RunValidators(ARCAEA_IMPL.scoreValidators, dmf(mockScore, s) as never, chart as never);
+		const runVal = (
+			s: DeepPartial<ScoreDocument<"arcaea">>,
+			c?: DeepPartial<ChartDocument<"arcaea">>,
+		) =>
+			RunValidators(
+				ARCAEA_IMPL.scoreValidators,
+				dmf(mockScore, s) as never,
+				dmf(chart, c ?? {}) as never,
+			);
 
 		it("accepts valid PM, FR, and chart score bounds", () => {
 			expect(
@@ -384,6 +392,23 @@ describe("ARCAEA_IMPL", () => {
 						judgements: { pure: 1120, far: 20, lost: 10 },
 					},
 				}),
+			).toBeUndefined();
+
+			expect(
+				runVal(
+					{
+						scoreData: {
+							lamp: "CLEAR",
+							score: 9_970_000,
+							judgements: { pure: 1150, far: 20, lost: 10 },
+						},
+					},
+					{
+						data: {
+							notecount: undefined,
+						},
+					},
+				),
 			).toBeUndefined();
 		});
 	});

--- a/typescript/server/src/game-implementations/games/arcaea.ts
+++ b/typescript/server/src/game-implementations/games/arcaea.ts
@@ -139,5 +139,13 @@ export const ARCAEA_IMPL: GameImplementation<"arcaea"> = {
 				}
 			}
 		},
+		(s, c) => {
+			const { pure, far, lost } = s.scoreData.judgements;
+
+			const total = (pure ?? 0) + (far ?? 0) + (lost ?? 0);
+			if (total > 0 && c.data.notecount !== undefined && total > c.data.notecount) {
+				return `Too many judgements: received ${total} in total but the chart's note count is ${c.data.notecount}.`;
+			}
+		},
 	],
 };


### PR DESCRIPTION
Adds a check that forbids too many judgements, i.e. the sum of all judgements being greater than notecount. 