### PR TITLE
feat: generalize ImportSQLiteForm for plaintext input + yurisaki import

### DIFF
--- a/typescript/client/src/app/pages/dashboard/import/ArcaeaST3Page.tsx
+++ b/typescript/client/src/app/pages/dashboard/import/ArcaeaST3Page.tsx
@@ -1,4 +1,4 @@
-import ImportSQLiteForm from "#components/imports/ImportSQLiteForm";
+import ImportFileForm from "#components/imports/ImportFileForm";
 import useSetSubheader from "#components/layout/header/useSetSubheader";
 import { convertArcaeaDB } from "#util/db-converters/arcaea";
 import React from "react";
@@ -18,7 +18,7 @@ export default function ArcaeaST3Page() {
 				seek a different method.
 			</Alert>
 
-			<ImportSQLiteForm
+			<ImportFileForm
 				convert={(dbs) => {
 					const { result, warnings } = convertArcaeaDB(dbs.st3!);
 					return { results: result.scores.length > 0 ? [result] : [], warnings };
@@ -26,6 +26,7 @@ export default function ArcaeaST3Page() {
 				fileFormat=""
 				fileInputs={[{ key: "st3", label: "Arcaea st3" }]}
 				name="Arcaea Database Import"
+				type="sql"
 			/>
 		</>
 	);

--- a/typescript/client/src/app/pages/dashboard/import/ArcaeaYurisakiPage.tsx
+++ b/typescript/client/src/app/pages/dashboard/import/ArcaeaYurisakiPage.tsx
@@ -1,0 +1,70 @@
+import ImportFileForm from "#components/imports/ImportFileForm";
+import useSetSubheader from "#components/layout/header/useSetSubheader";
+import { convertYurisakiCSV } from "#util/db-converters/arcaea";
+import React from "react";
+import { Alert } from "react-bootstrap";
+
+export default function ArcaeaYurisakiPage() {
+	useSetSubheader(["Import Scores", "Arcaea Yurisaki"]);
+
+	return (
+		<>
+			<Alert variant="warning">
+				Use this method only if you're unable to use{" "}
+				<a href="/import/arcaea-st3">the ST3 method</a>.
+			</Alert>
+			<Alert variant="info">
+				Usage:
+				<ol>
+					<li>
+						Add <a href="https://arcaea.yurisaki.top/bot">the Telegram bot</a>
+					</li>
+					<li>
+						<code>/a bind &lt;friendcode&gt;</code>
+					</li>
+					<li>
+						<code>/a account claim</code>
+						<ul>
+							<li>
+								It will ask to switch to a specific parter in-game; you will need
+								remove the favorite character temporarily
+							</li>
+							<li>
+								<code>/a account check</code> when done.
+							</li>
+						</ul>
+					</li>
+					<li>
+						<code>/a b30</code> (takes a while)
+					</li>
+					<li>
+						<code>/a export</code>
+					</li>
+					<li>
+						Extract <code>all_scores.csv</code>
+					</li>
+				</ol>
+			</Alert>
+			<Alert variant="warning">
+				This method is intended for syncing up with old (existing) scores. Don't abuse the
+				bot for new scores.
+			</Alert>
+
+			<ImportFileForm
+				convert={(dbs) => {
+					const csv = dbs["yurisaki-csv"];
+					if (csv) {
+						const { result, warnings } = convertYurisakiCSV(csv);
+						return { results: result.scores.length > 0 ? [result] : [], warnings };
+					}
+
+					return { results: [], warnings: [] };
+				}}
+				fileFormat="csv"
+				fileInputs={[{ key: "yurisaki-csv", label: "Yurisaki CSV" }]}
+				name="Arcaea Database Import"
+				type="plaintext"
+			/>
+		</>
+	);
+}

--- a/typescript/client/src/app/pages/dashboard/import/ImportPage.tsx
+++ b/typescript/client/src/app/pages/dashboard/import/ImportPage.tsx
@@ -410,10 +410,19 @@ function ImportInfoDisplayer({ game }: { game: GameGroup }) {
 	} else if (game === "arcaea") {
 		Content.unshift(
 			<ImportInfoCard
+				desc="Import PBs from a Telegram bot."
+				href="arcaea-yurisaki"
+				key="Yurisaki"
+				moreInfo="This method is intended for syncing up old scores."
+				name="Yurisaki"
+			/>,
+		);
+		Content.unshift(
+			<ImportInfoCard
 				desc="Import PBs from your local savefile."
 				href="arcaea-st3"
 				key="Arcaea ST3"
-				moreInfo="This method is intended for syncing up old scores offline. "
+				moreInfo="This method is intended for syncing up old scores offline."
 				name="ST3 Import"
 			/>,
 		);

--- a/typescript/client/src/app/pages/dashboard/import/LR2DBPage.tsx
+++ b/typescript/client/src/app/pages/dashboard/import/LR2DBPage.tsx
@@ -1,4 +1,4 @@
-import ImportSQLiteForm from "#components/imports/ImportSQLiteForm";
+import ImportFileForm from "#components/imports/ImportFileForm";
 import useSetSubheader from "#components/layout/header/useSetSubheader";
 import Divider from "#components/util/Divider";
 import Muted from "#components/util/Muted";
@@ -10,7 +10,7 @@ export default function LR2DBPage() {
 
 	return (
 		<>
-			<ImportSQLiteForm
+			<ImportFileForm
 				convert={(dbs) => {
 					const { k7, k14, warnings } = convertLR2Db(dbs.score!, dbs.chart!);
 					const results = [k7, k14].filter((r) => r !== null);
@@ -21,6 +21,7 @@ export default function LR2DBPage() {
 					{ key: "chart", label: "LR2 song.db" },
 				]}
 				name="LR2 Database Import"
+				type="sql"
 			/>
 
 			<Divider />

--- a/typescript/client/src/app/pages/dashboard/import/LR2orajaDBPage.tsx
+++ b/typescript/client/src/app/pages/dashboard/import/LR2orajaDBPage.tsx
@@ -1,4 +1,4 @@
-import ImportSQLiteForm from "#components/imports/ImportSQLiteForm";
+import ImportFileForm from "#components/imports/ImportFileForm";
 import useSetSubheader from "#components/layout/header/useSetSubheader";
 import Divider from "#components/util/Divider";
 import Muted from "#components/util/Muted";
@@ -11,7 +11,7 @@ export default function LR2orajaDBPage() {
 
 	return (
 		<>
-			<ImportSQLiteForm
+			<ImportFileForm
 				convert={(dbs) => {
 					const { k7, k14, warnings } = convertBeatorajaDb(dbs.score!, dbs.chart!);
 					const results = [k7, k14].filter((r) => r !== null);
@@ -22,6 +22,7 @@ export default function LR2orajaDBPage() {
 					{ key: "chart", label: "Beatoraja songdata.db" },
 				]}
 				name="LR2oraja (Beatoraja) Database Import"
+				type="sql"
 			/>
 
 			<Divider />

--- a/typescript/client/src/app/pages/dashboard/import/USCDBPage.tsx
+++ b/typescript/client/src/app/pages/dashboard/import/USCDBPage.tsx
@@ -1,4 +1,4 @@
-import ImportSQLiteForm from "#components/imports/ImportSQLiteForm";
+import ImportFileForm from "#components/imports/ImportFileForm";
 import useSetSubheader from "#components/layout/header/useSetSubheader";
 import Divider from "#components/util/Divider";
 import Muted from "#components/util/Muted";
@@ -20,7 +20,7 @@ export default function USCDBPage() {
 				uploading.
 			</Alert>
 
-			<ImportSQLiteForm
+			<ImportFileForm
 				convert={(dbs) => {
 					if (playtype === "") {
 						throw new Error("Please select an input device.");
@@ -52,6 +52,7 @@ export default function USCDBPage() {
 				extraValid={playtype !== ""}
 				fileInputs={[{ key: "db", label: "USC maps.db" }]}
 				name="USC Database Import"
+				type="sql"
 			/>
 
 			<Divider />

--- a/typescript/client/src/app/routes/ImportRoutes.tsx
+++ b/typescript/client/src/app/routes/ImportRoutes.tsx
@@ -1,5 +1,6 @@
 import AquaArtemisExport from "#app/pages/dashboard/import/AquaArtemisExportPage";
 import ArcaeaST3Page from "#app/pages/dashboard/import/ArcaeaST3Page";
+import ArcaeaYurisakiPage from "#app/pages/dashboard/import/ArcaeaYurisakiPage";
 import BarbatosPage from "#app/pages/dashboard/import/BarbatosPage";
 import BatchManualPage from "#app/pages/dashboard/import/BatchManualPage";
 import BeatorajaIRPage from "#app/pages/dashboard/import/BeatorajaIRPage";
@@ -283,6 +284,10 @@ export default function ImportRoutes() {
 
 							<Route exact path="/import/arcaea-st3">
 								<ArcaeaST3Page />
+							</Route>
+
+							<Route exact path="/import/arcaea-yurisaki">
+								<ArcaeaYurisakiPage />
 							</Route>
 						</>
 					)}

--- a/typescript/client/src/components/imports/ImportFileForm.tsx
+++ b/typescript/client/src/components/imports/ImportFileForm.tsx
@@ -26,7 +26,7 @@ export interface SQLiteFileInput {
 	key: string;
 }
 
-interface Props {
+interface BaseProps {
 	/** Heading for this import form. */
 	name: string;
 	/** One file input (USC) or two (LR2 / Beatoraja). */
@@ -40,6 +40,9 @@ interface Props {
 	extraValid?: boolean;
 	/** Target file format (default: .db) */
 	fileFormat?: string;
+}
+
+interface SQLProps extends BaseProps {
 	/**
 	 * Conversion function.  Receives a map of `key → opened Database` and
 	 * returns one or more Batch Manual documents plus any warnings.
@@ -47,7 +50,19 @@ interface Props {
 	 * are a few thousand rows, so this should be fine).
 	 */
 	convert: (dbs: Record<string, Database>) => ConvertResult;
+	type: "sql";
 }
+
+interface PlaintextProps extends BaseProps {
+	/**
+	 * Conversion function.  Receives a map of `key → file contents` and
+	 * returns one or more Batch Manual documents plus any warnings.
+	 */
+	convert: (dbs: Record<string, string>) => ConvertResult;
+	type: "plaintext";
+}
+
+type Props = PlaintextProps | SQLProps;
 
 type ConvertState =
 	| { message: string; phase: "error" }
@@ -55,12 +70,13 @@ type ConvertState =
 	| { phase: "loading" }
 	| { phase: "preview"; results: unknown[]; warnings: ConvertWarning[] };
 
-export default function ImportSQLiteForm({
+export default function ImportFileForm({
 	name,
 	fileInputs,
 	extraControls,
 	extraValid = true,
 	fileFormat,
+	type,
 	convert,
 }: Props) {
 	// One File ref per declared file input
@@ -95,18 +111,26 @@ export default function ImportSQLiteForm({
 
 		setConvertState({ phase: "loading" });
 
-		const dbs: Record<string, Database> = {};
+		const dbs: Record<string, Database> | Record<string, string> = {};
+		let results, warnings;
 		try {
-			for (const { key } of fileInputs) {
-				dbs[key] = await openDatabase(files[key]!);
-			}
+			if (type === "sql") {
+				for (const { key } of fileInputs) {
+					dbs[key] = await openDatabase(files[key]!);
+				}
+				({ results, warnings } = convert(dbs as Record<string, Database>));
+			} else {
+				for (const { key } of fileInputs) {
+					dbs[key] = new TextDecoder().decode(await files[key]!.arrayBuffer());
+				}
 
-			const { results, warnings } = convert(dbs);
+				({ results, warnings } = convert(dbs as Record<string, string>));
+			}
 
 			if (results.length === 0) {
 				setConvertState({
 					phase: "error",
-					message: "No importable scores were found in the database.",
+					message: `No importable scores were found${type === "sql" ? " in the database" : ""}.`,
 				});
 				return;
 			}
@@ -118,11 +142,13 @@ export default function ImportSQLiteForm({
 				message: err instanceof Error ? err.message : String(err),
 			});
 		} finally {
-			for (const db of Object.values(dbs)) {
-				try {
-					db.close();
-				} catch {
-					// ignore
+			if (type === "sql") {
+				for (const db of Object.values(dbs)) {
+					try {
+						db.close();
+					} catch {
+						// ignore
+					}
 				}
 			}
 		}
@@ -166,8 +192,8 @@ export default function ImportSQLiteForm({
 			<h2 className="text-center">{name}</h2>
 
 			<Alert variant="warning">
-				Processing your database file runs entirely in your browser. Depending on the number
-				of scores, this may use significant CPU for a few seconds. This is expected.
+				Processing the file runs entirely in your browser. Depending on the number of
+				scores, this may use significant CPU for a few seconds. This is expected.
 			</Alert>
 			{fileInputs.map(({ key, label }) => (
 				<Form.Group key={key}>

--- a/typescript/client/src/util/db-converters/arcaea.ts
+++ b/typescript/client/src/util/db-converters/arcaea.ts
@@ -1,4 +1,5 @@
 import { type Database } from "sql.js";
+import { type BatchManualScore } from "tachi-common";
 
 import { queryAll } from "./sql-loader";
 
@@ -14,8 +15,24 @@ interface ArcaeaST3ScoreRow {
 	clearType: number;
 }
 
-const getDifficulty = (score: ArcaeaST3ScoreRow) => {
-	switch (score.songDifficulty) {
+interface ArcaeaYurisakiCSVRow {
+	songId: string;
+	songDifficulty: number;
+	score: number;
+	// constant: number;
+	// potential: number;
+	// ls: number;
+	// shinyPerfectCount: number;
+	perfectCount: number;
+	nearCount: number;
+	missCount: number;
+	clearType: number;
+	timestamp: number;
+	// dateTime: string;
+}
+
+const getDifficulty = (songDifficulty: number) => {
+	switch (songDifficulty) {
 		case 0:
 			return "Past";
 		case 1:
@@ -27,12 +44,12 @@ const getDifficulty = (score: ArcaeaST3ScoreRow) => {
 		case 4:
 			return "Eternal";
 		default:
-			throw new Error(`Unknown difficulty ${score.songDifficulty}`);
+			throw new Error(`Unknown difficulty ${songDifficulty}`);
 	}
 };
 
-const getLamp = (score: ArcaeaST3ScoreRow) => {
-	switch (score.clearType) {
+const getLamp = (clearType: number) => {
+	switch (clearType) {
 		case 0:
 			return "LOST";
 		case 1:
@@ -46,7 +63,7 @@ const getLamp = (score: ArcaeaST3ScoreRow) => {
 		case 5:
 			return "HARD CLEAR";
 		default:
-			throw new Error(`Unknown clearType ${score.clearType}`);
+			throw new Error(`Unknown clearType ${clearType}`);
 	}
 };
 
@@ -63,10 +80,10 @@ export interface ArcaeaBatchManual {
 		game: "arcaea";
 		service: string;
 	};
-	scores: unknown[];
+	scores: BatchManualScore<"arcaea">[];
 }
 
-export function convertArcaeaDB(db: Database): { result: ArcaeaBatchManual; warnings: [] } {
+export const convertArcaeaDB = (db: Database): { result: ArcaeaBatchManual; warnings: [] } => {
 	const rows = queryAll<ArcaeaST3ScoreRow>(
 		db,
 		`SELECT
@@ -85,12 +102,12 @@ export function convertArcaeaDB(db: Database): { result: ArcaeaBatchManual; warn
 			AND scores.songDifficulty = cleartypes.songDifficulty`,
 	);
 
-	const scores = [];
+	const scores: BatchManualScore<"arcaea">[] = [];
 
 	for (const row of rows) {
 		let judgements;
-		if (row.missCount > 0 && getLamp(row) === "FULL RECALL") {
-			judgements = {};
+		if (row.missCount > 0 && getLamp(row.clearType) === "FULL RECALL") {
+			judgements = undefined;
 		} else {
 			judgements = {
 				pure: row.perfectCount,
@@ -101,9 +118,9 @@ export function convertArcaeaDB(db: Database): { result: ArcaeaBatchManual; warn
 		scores.push({
 			identifier: row.songId,
 			matchType: "inGameStrID",
-			difficulty: getDifficulty(row),
+			difficulty: getDifficulty(row.songDifficulty),
 			score: row.score,
-			lamp: getLamp(row),
+			lamp: getLamp(row.clearType),
 			timeAchieved: normalizeTimestamp(row.date),
 			optional: {},
 			scoreMeta: {},
@@ -118,4 +135,85 @@ export function convertArcaeaDB(db: Database): { result: ArcaeaBatchManual; warn
 		},
 		warnings: [],
 	};
-}
+};
+
+const parseYurisakiCSVRow = (row: string): ArcaeaYurisakiCSVRow => {
+	const matches = (row.match(/,/gu) ?? []).length;
+	if (matches !== 12) {
+		throw new Error(`Invalid CSV: expected 13 fields per row; got ${matches + 1}`);
+	}
+
+	const [
+		songId,
+		songDifficulty,
+		score,
+		_constant,
+		_potential,
+		_ls,
+		_shinyPerfectCount,
+		perfectCount,
+		nearCount,
+		missCount,
+		clearType,
+		timestamp,
+		_dateTime,
+	] = row.split(",");
+
+	const number = (str: string) => {
+		const rv = Number(str);
+		if (!Number.isFinite(rv)) {
+			throw new Error(`Invalid number ${str}`);
+		}
+		return rv;
+	};
+
+	return {
+		songId,
+		songDifficulty: number(songDifficulty),
+		score: number(score),
+		perfectCount: number(perfectCount),
+		nearCount: number(nearCount),
+		missCount: number(missCount),
+		clearType: number(clearType),
+		timestamp: number(timestamp),
+	};
+};
+
+export const convertYurisakiCSV = (csv: string) => {
+	const scores: BatchManualScore<"arcaea">[] = [];
+	for (const row of csv.trim().split("\n").slice(1)) {
+		const sc = parseYurisakiCSVRow(row);
+		const lamp = getLamp(sc.clearType);
+
+		let judgements;
+		if (sc.missCount > 0 && lamp === "FULL RECALL") {
+			judgements = undefined;
+		} else {
+			judgements = {
+				pure: sc.perfectCount,
+				far: sc.nearCount,
+				lost: sc.missCount,
+			};
+		}
+
+		scores.push({
+			identifier: sc.songId,
+			matchType: "inGameStrID",
+			difficulty: getDifficulty(sc.songDifficulty),
+			score: sc.score,
+			lamp,
+			timeAchieved: sc.timestamp,
+			optional: {},
+			scoreMeta: {},
+			judgements,
+		});
+	}
+
+	return {
+		result: {
+			meta: { game: "arcaea", service: "Yurisaki" },
+			scores,
+		},
+		warnings: [],
+	};
+};


### PR DESCRIPTION
ImportSQLiteForm is really nice. I slightly tweaked it to allow plaintext, as I think that's more elegant than adding another dedicated importer type into the server side. I added an alternative score import method for Arcaea for players without a rooted device. Good luck extinguishing the fire in the Library of Alexandria.