### PR TITLE
fix: update rating state on alg change in PBTable

### DIFF
--- a/typescript/client/src/components/tables/pbs/PBTable.tsx
+++ b/typescript/client/src/components/tables/pbs/PBTable.tsx
@@ -3,7 +3,7 @@ import { type PBDataset } from "#types/tables";
 import { NumericSOV } from "#util/sorts";
 import { CreateDefaultPBSearchParams } from "#util/tables/create-search";
 import { GetPBLeadingHeaders } from "#util/tables/get-pb-leaders";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { type AnyScoreRatingAlg, type V3Game } from "tachi-common";
 
 import DropdownIndicatorCell from "../cells/DropdownIndicatorCell";
@@ -41,8 +41,11 @@ export default function PBTable({
 	showUser?: boolean;
 }) {
 	const defaultRating = useScoreRatingAlg(game);
-
 	const [rating, setRating] = useState(alg ?? defaultRating);
+
+	useEffect(() => {
+		setRating(alg ?? defaultRating);
+	}, [alg, defaultRating]);
 	const [rankingViewMode, setRankingViewMode] = useState<RankingViewMode>(
 		defaultRankingViewMode ?? "global",
 	);


### PR DESCRIPTION
Changes in "alg" state caused by AlgSelector should be in sync with "rating" state used by ScoreCoreCells to avoid data mismatch

Example: VF7 alg selected but rating cell is displayed as VF6
<img width="1327" height="864" alt="image" src="https://github.com/user-attachments/assets/b27a5af1-e396-449b-9023-678906f2b2f7" />
