### PR TITLE
Reconcile missing chart leaderboard rows

### DIFF
--- a/typescript/server/src/lib/jobs/chart-leaderboard.test.ts
+++ b/typescript/server/src/lib/jobs/chart-leaderboard.test.ts
@@ -1,0 +1,108 @@
+import { ReconcileChartLeaderboardJob } from "#lib/jobs/reconcile-chart-leaderboard";
+import DB from "#services/pg/db";
+import { seedUser } from "#test-utils/pg-fixtures";
+import { describe, expect, it } from "vitest";
+
+function makeSongId(n: number): string {
+	return `SL${n.toString(16).padStart(20, "0")}`;
+}
+
+function makeChartId(n: number): string {
+	return `CL${n.toString(16).padStart(20, "0")}`;
+}
+
+function makeLegacyId(n: number): string {
+	return `leaderboard_${n.toString(16).padStart(28, "0")}`;
+}
+
+async function insertSongAndChart(songId: string, chartId: string) {
+	await DB.insertInto("song")
+		.values({
+			id: songId,
+			legacy_id: 9_020_000,
+			game_group: "iidx",
+			title: "Leaderboard Reconcile Song",
+			artist: "X",
+			search_terms: [],
+			alt_titles: [],
+			fts_document: "",
+			data: JSON.stringify({}),
+		})
+		.execute();
+
+	await DB.insertInto("chart")
+		.values({
+			id: chartId,
+			legacy_id: makeLegacyId(1),
+			game: "iidx-sp",
+			song_id: songId,
+			level: "10",
+			level_num: 10,
+			is_primary: true,
+			difficulty: "ANOTHER",
+			versions: [],
+			data: JSON.stringify({ notecount: 100 }),
+		})
+		.execute();
+}
+
+describe("chart_leaderboard reconciliation", () => {
+	it("rebuilds missing leaderboard rows for existing PBs", async () => {
+		const songId = makeSongId(1);
+		const chartId = makeChartId(1);
+
+		await insertSongAndChart(songId, chartId);
+
+		const { id: userId } = await seedUser({ username: "leaderboard_reconcile_user" });
+
+		const pbRow = await DB.insertInto("pb")
+			.values({
+				user_id: userId,
+				chart_id: chartId,
+				lens: null,
+				data: JSON.stringify({}),
+				derived_data: JSON.stringify({}),
+				calculated_data: JSON.stringify({}),
+				judgements: JSON.stringify({}),
+				ranking_value: 123,
+				ranking_value_tb1: null,
+				ranking_value_tb2: null,
+				ranking_value_tb3: null,
+				ranking_value_tb4: null,
+				ranking_value_tb5: null,
+				highlight: false,
+				time_achieved: new Date().toISOString(),
+			})
+			.returning("row_id")
+			.executeTakeFirstOrThrow();
+
+		let leaderboardRows = await DB.selectFrom("chart_leaderboard")
+			.select(["chart_leaderboard.row_id"])
+			.where("chart_leaderboard.row_id", "=", pbRow.row_id)
+			.execute();
+
+		expect(leaderboardRows).toHaveLength(1);
+
+		await DB.deleteFrom("chart_leaderboard")
+			.where("chart_leaderboard.row_id", "=", pbRow.row_id)
+			.execute();
+
+		leaderboardRows = await DB.selectFrom("chart_leaderboard")
+			.select(["chart_leaderboard.row_id"])
+			.where("chart_leaderboard.row_id", "=", pbRow.row_id)
+			.execute();
+
+		expect(leaderboardRows).toHaveLength(0);
+
+		const refreshed = await ReconcileChartLeaderboardJob();
+
+		expect(refreshed).toBe(1);
+
+		const rebuiltRows = await DB.selectFrom("chart_leaderboard")
+			.select(["chart_leaderboard.rank", "chart_leaderboard.out_of"])
+			.where("chart_leaderboard.row_id", "=", pbRow.row_id)
+			.execute();
+
+		expect(rebuiltRows).toEqual([{ out_of: 1, rank: 1 }]);
+	});
+});

--- a/typescript/server/src/lib/jobs/drain-dirty-queues.ts
+++ b/typescript/server/src/lib/jobs/drain-dirty-queues.ts
@@ -4,6 +4,7 @@ import {
 	ToScoreDocument,
 } from "#lib/db-formats/score";
 import { SELECT_SESSION_DOCUMENT } from "#lib/db-formats/session";
+import { ReconcileChartLeaderboardJob } from "#lib/jobs/reconcile-chart-leaderboard";
 import { log } from "#lib/log/log";
 import { CreateSessionCalcData } from "#lib/score-import/framework/calculated-data/session";
 import { ProcessPBs } from "#lib/score-import/framework/pb/process-pbs";
@@ -34,6 +35,21 @@ const SCORE_REDERIVE_CAP = 50_000;
 const PB_DIRTY_CAP = 100_000;
 const SESSION_DIRTY_CAP = 50_000;
 const GAME_PROFILE_DIRTY_CAP = 5_000;
+
+async function hasDownstreamDirtyWork(): Promise<boolean> {
+	const [sessionDirty, gameProfileDirty] = await Promise.all([
+		DB.selectFrom("session_dirty")
+			.select("session_dirty.session_id")
+			.limit(1)
+			.executeTakeFirst(),
+		DB.selectFrom("game_profile_dirty")
+			.select(["game_profile_dirty.user_id", "game_profile_dirty.game"])
+			.limit(1)
+			.executeTakeFirst(),
+	]);
+
+	return sessionDirty !== undefined || gameProfileDirty !== undefined;
+}
 
 /**
  * Drain the `pb_dirty` queue: group entries by (game, playtype, user_id),
@@ -322,6 +338,15 @@ export async function drainStatsQueuesInOrder(): Promise<void> {
 			cycleMoved += n;
 		}
 
+		// Seed/dataset restores can contain pb rows without their cached
+		// chart_leaderboard rows. Repair those before downstream recalculation,
+		// otherwise inner joins on chart_leaderboard hide otherwise-valid PBs.
+		// eslint-disable-next-line no-await-in-loop
+		if (pbProcessed > 0 || (await hasDownstreamDirtyWork())) {
+			// eslint-disable-next-line no-await-in-loop
+			cycleMoved += await ReconcileChartLeaderboardJob();
+		}
+
 		let sessionProcessed = 0;
 
 		while (sessionProcessed < SESSION_DIRTY_CAP) {
@@ -389,6 +414,8 @@ export async function drainStatsQueuesFully(): Promise<void> {
 			cycleMoved += n;
 		}
 
+		cycleMoved += await ReconcileChartLeaderboardJob();
+
 		while (true) {
 			const n = await drainSessionDirty();
 
@@ -432,6 +459,8 @@ export async function drainPbDirtyAndDownstream(): Promise<void> {
 
 			cycleMoved += n;
 		}
+
+		cycleMoved += await ReconcileChartLeaderboardJob();
 
 		while (true) {
 			const n = await drainSessionDirty();

--- a/typescript/server/src/lib/jobs/reconcile-chart-leaderboard.ts
+++ b/typescript/server/src/lib/jobs/reconcile-chart-leaderboard.ts
@@ -1,0 +1,44 @@
+import { log } from "#lib/log/log";
+import DB from "#services/pg/db";
+import { sql } from "kysely";
+
+interface LeaderboardPartition {
+	chart_id: string;
+	lens: string | null;
+}
+
+/**
+ * Rebuild chart_leaderboard partitions that are missing cached rows.
+ *
+ * Normal writes are maintained by pb triggers, but seed/dataset restores can
+ * arrive with pb rows and no chart_leaderboard rows. Downstream PB/profile
+ * queries use an inner join on chart_leaderboard, so missing rows make valid PBs
+ * disappear from recalculation until the partition is refreshed.
+ */
+export async function ReconcileChartLeaderboardJob(): Promise<number> {
+	const missingPartitions = await sql<LeaderboardPartition>`
+		SELECT DISTINCT
+			pb.chart_id,
+			pb.lens
+		FROM pb
+		LEFT JOIN chart_leaderboard AS cl ON cl.row_id = pb.row_id
+		WHERE cl.row_id IS NULL
+	`.execute(DB);
+
+	for (const partition of missingPartitions.rows) {
+		await sql`
+			SELECT refresh_chart_leaderboard_partition(
+				${partition.chart_id},
+				${partition.lens}
+			)
+		`.execute(DB);
+	}
+
+	if (missingPartitions.rows.length > 0) {
+		log.info(
+			`ReconcileChartLeaderboard done: ${missingPartitions.rows.length} partition(s) refreshed.`,
+		);
+	}
+
+	return missingPartitions.rows.length;
+}


### PR DESCRIPTION
Fixes #1630

## Summary
- adds a chart_leaderboard reconciliation job that finds PB partitions with missing cached leaderboard rows and refreshes them with the existing refresh_chart_leaderboard_partition function
- runs the reconciliation before session/profile dirty queues drain so restored datasets cannot hide valid PBs behind chart_leaderboard inner joins
- adds a regression test that deletes a cached leaderboard row and verifies the reconciliation rebuilds rank/out_of for the PB

## Tests
- git diff --check
- git diff --cached --check

Not run: bun/vitest tests. This local environment has no usable bun/pnpm/npm on PATH and repo dependencies are not installed.