### PR TITLE
Fix score dirty queue deadlocks during stats drains

### DIFF
--- a/db/migrations/20260604032000_score_dirty_statement_triggers.sql
+++ b/db/migrations/20260604032000_score_dirty_statement_triggers.sql
@@ -1,0 +1,213 @@
+-- The score dirty-queue triggers used to run once per row. During large
+-- rederive/import UPDATEs, parallel transactions could insert overlapping
+-- session_dirty / pb_dirty / game_profile_dirty keys in different row orders
+-- and deadlock inside the unique indexes despite ON CONFLICT DO NOTHING.
+--
+-- Use AFTER STATEMENT transition tables instead: each statement inserts each
+-- dirty key once, in deterministic key order.
+
+DROP TRIGGER "score_pb_dirty" ON score;
+DROP TRIGGER "score_session_dirty" ON score;
+DROP TRIGGER "score_game_profile_dirty" ON score;
+
+DROP FUNCTION enqueue_pb_dirty();
+DROP FUNCTION enqueue_session_dirty();
+DROP FUNCTION enqueue_game_profile_dirty();
+
+CREATE FUNCTION enqueue_pb_dirty()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+	IF TG_OP = 'DELETE' THEN
+		INSERT INTO pb_dirty (user_id, chart_id)
+		SELECT DISTINCT
+			score_deleted.user_id,
+			score_deleted.chart_id
+		FROM score_deleted
+		ORDER BY score_deleted.user_id, score_deleted.chart_id
+		ON CONFLICT DO NOTHING;
+	ELSIF TG_OP = 'UPDATE' THEN
+		INSERT INTO pb_dirty (user_id, chart_id)
+		SELECT DISTINCT
+			d.user_id,
+			d.chart_id
+		FROM (
+			SELECT
+				score_updated_old.user_id,
+				score_updated_old.chart_id
+			FROM score_updated_old
+			UNION
+			SELECT
+				score_updated_new.user_id,
+				score_updated_new.chart_id
+			FROM score_updated_new
+		) AS d
+		ORDER BY d.user_id, d.chart_id
+		ON CONFLICT DO NOTHING;
+	ELSE
+		INSERT INTO pb_dirty (user_id, chart_id)
+		SELECT DISTINCT
+			score_inserted.user_id,
+			score_inserted.chart_id
+		FROM score_inserted
+		ORDER BY score_inserted.user_id, score_inserted.chart_id
+		ON CONFLICT DO NOTHING;
+	END IF;
+
+	RETURN NULL;
+END;
+$$;
+
+CREATE FUNCTION enqueue_session_dirty()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+	IF TG_OP = 'DELETE' THEN
+		INSERT INTO session_dirty (session_id)
+		SELECT DISTINCT score_deleted.session_id
+		FROM score_deleted
+		WHERE
+			score_deleted.committed
+			AND score_deleted.session_id IS NOT NULL
+		ORDER BY score_deleted.session_id
+		ON CONFLICT DO NOTHING;
+	ELSIF TG_OP = 'UPDATE' THEN
+		INSERT INTO session_dirty (session_id)
+		SELECT DISTINCT d.session_id
+		FROM (
+			SELECT score_updated_old.session_id
+			FROM score_updated_old
+			WHERE
+				score_updated_old.committed
+				AND score_updated_old.session_id IS NOT NULL
+			UNION
+			SELECT score_updated_new.session_id
+			FROM score_updated_new
+			WHERE
+				score_updated_new.committed
+				AND score_updated_new.session_id IS NOT NULL
+		) AS d
+		ORDER BY d.session_id
+		ON CONFLICT DO NOTHING;
+	ELSE
+		INSERT INTO session_dirty (session_id)
+		SELECT DISTINCT score_inserted.session_id
+		FROM score_inserted
+		WHERE
+			score_inserted.committed
+			AND score_inserted.session_id IS NOT NULL
+		ORDER BY score_inserted.session_id
+		ON CONFLICT DO NOTHING;
+	END IF;
+
+	RETURN NULL;
+END;
+$$;
+
+CREATE FUNCTION enqueue_game_profile_dirty()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+	IF TG_OP = 'DELETE' THEN
+		INSERT INTO game_profile_dirty (user_id, game)
+		SELECT DISTINCT
+			score_deleted.user_id,
+			score_deleted.game
+		FROM score_deleted
+		WHERE score_deleted.committed
+		ORDER BY score_deleted.user_id, score_deleted.game
+		ON CONFLICT DO NOTHING;
+	ELSIF TG_OP = 'UPDATE' THEN
+		INSERT INTO game_profile_dirty (user_id, game)
+		SELECT DISTINCT
+			d.user_id,
+			d.game
+		FROM (
+			SELECT
+				score_updated_old.user_id,
+				score_updated_old.game
+			FROM score_updated_old
+			WHERE score_updated_old.committed
+			UNION
+			SELECT
+				score_updated_new.user_id,
+				score_updated_new.game
+			FROM score_updated_new
+			WHERE score_updated_new.committed
+		) AS d
+		ORDER BY d.user_id, d.game
+		ON CONFLICT DO NOTHING;
+	ELSE
+		INSERT INTO game_profile_dirty (user_id, game)
+		SELECT DISTINCT
+			score_inserted.user_id,
+			score_inserted.game
+		FROM score_inserted
+		WHERE score_inserted.committed
+		ORDER BY score_inserted.user_id, score_inserted.game
+		ON CONFLICT DO NOTHING;
+	END IF;
+
+	RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER "score_pb_dirty"
+	AFTER INSERT ON score
+	REFERENCING NEW TABLE AS score_inserted
+	FOR EACH STATEMENT
+	EXECUTE FUNCTION enqueue_pb_dirty();
+
+CREATE TRIGGER "score_pb_dirty_update"
+	AFTER UPDATE ON score
+	REFERENCING OLD TABLE AS score_updated_old NEW TABLE AS score_updated_new
+	FOR EACH STATEMENT
+	EXECUTE FUNCTION enqueue_pb_dirty();
+
+CREATE TRIGGER "score_pb_dirty_delete"
+	AFTER DELETE ON score
+	REFERENCING OLD TABLE AS score_deleted
+	FOR EACH STATEMENT
+	EXECUTE FUNCTION enqueue_pb_dirty();
+
+CREATE TRIGGER "score_session_dirty"
+	AFTER INSERT ON score
+	REFERENCING NEW TABLE AS score_inserted
+	FOR EACH STATEMENT
+	EXECUTE FUNCTION enqueue_session_dirty();
+
+CREATE TRIGGER "score_session_dirty_update"
+	AFTER UPDATE ON score
+	REFERENCING OLD TABLE AS score_updated_old NEW TABLE AS score_updated_new
+	FOR EACH STATEMENT
+	EXECUTE FUNCTION enqueue_session_dirty();
+
+CREATE TRIGGER "score_session_dirty_delete"
+	AFTER DELETE ON score
+	REFERENCING OLD TABLE AS score_deleted
+	FOR EACH STATEMENT
+	EXECUTE FUNCTION enqueue_session_dirty();
+
+CREATE TRIGGER "score_game_profile_dirty"
+	AFTER INSERT ON score
+	REFERENCING NEW TABLE AS score_inserted
+	FOR EACH STATEMENT
+	EXECUTE FUNCTION enqueue_game_profile_dirty();
+
+CREATE TRIGGER "score_game_profile_dirty_update"
+	AFTER UPDATE ON score
+	REFERENCING OLD TABLE AS score_updated_old NEW TABLE AS score_updated_new
+	FOR EACH STATEMENT
+	EXECUTE FUNCTION enqueue_game_profile_dirty();
+
+CREATE TRIGGER "score_game_profile_dirty_delete"
+	AFTER DELETE ON score
+	REFERENCING OLD TABLE AS score_deleted
+	FOR EACH STATEMENT
+	EXECUTE FUNCTION enqueue_game_profile_dirty();

--- a/typescript/server/src/lib/jobs/drain-dirty-queues.test.ts
+++ b/typescript/server/src/lib/jobs/drain-dirty-queues.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { drainUntilIdleOrCap } from "./drain-dirty-queues";
+
+describe("drainUntilIdleOrCap", () => {
+	it("stops when the queue reports empty before the cap is reached", async () => {
+		const batches = [3, 2, 0, 5];
+		let calls = 0;
+
+		const result = await drainUntilIdleOrCap(async () => {
+			calls += 1;
+			return batches.shift() ?? 0;
+		}, 10);
+
+		expect(result).toEqual({ capped: false, processed: 5 });
+		expect(calls).toBe(3);
+	});
+
+	it("stops at the cap without requiring a final empty probe", async () => {
+		let calls = 0;
+
+		const result = await drainUntilIdleOrCap(async () => {
+			calls += 1;
+			return 5;
+		}, 10);
+
+		expect(result).toEqual({ capped: true, processed: 10 });
+		expect(calls).toBe(2);
+	});
+});

--- a/typescript/server/src/lib/jobs/drain-dirty-queues.ts
+++ b/typescript/server/src/lib/jobs/drain-dirty-queues.ts
@@ -35,6 +35,26 @@ const PB_DIRTY_CAP = 100_000;
 const SESSION_DIRTY_CAP = 50_000;
 const GAME_PROFILE_DIRTY_CAP = 5_000;
 
+export async function drainUntilIdleOrCap(
+	drain: () => Promise<number>,
+	cap: number,
+): Promise<{ capped: boolean; processed: number }> {
+	let processed = 0;
+
+	while (processed < cap) {
+		// eslint-disable-next-line no-await-in-loop
+		const n = await drain();
+
+		if (n === 0) {
+			return { capped: false, processed };
+		}
+
+		processed += n;
+	}
+
+	return { capped: true, processed };
+}
+
 /**
  * Drain the `pb_dirty` queue: group entries by (game, playtype, user_id),
  * call ProcessPBs per group, and delete processed rows.
@@ -258,9 +278,9 @@ export async function drainGameProfileDirtyFully(): Promise<void> {
 }
 
 /**
- * Drain `score_rederive`, then `pb_dirty`, then `session_dirty`, then `game_profile_dirty`,
- * repeating until a full pass does nothing. Each queue has its own per-tick row budget so
- * a large `score_rederive` backlog cannot permanently starve the downstream queues.
+ * Drain `score_rederive`, then `pb_dirty`, then `session_dirty`, then `game_profile_dirty`.
+ * Each queue gets one bounded budget per cron tick so a large import/recalc backlog cannot
+ * monopolize the worker forever. Admin-triggered recalcs use the explicit "fully" helpers.
  * PBs must run before game profiles (ratings read from `pb`).
  */
 export async function drainStatsQueuesInOrder(): Promise<void> {
@@ -291,68 +311,24 @@ export async function drainStatsQueuesInOrder(): Promise<void> {
 		"drainStatsQueuesInOrder: queue sizes at tick start",
 	);
 
-	while (true) {
-		let cycleMoved = 0;
+	const scoreRederive = await drainUntilIdleOrCap(drainScoreRederive, SCORE_REDERIVE_CAP);
+	const pbDirty = await drainUntilIdleOrCap(drainPbDirty, PB_DIRTY_CAP);
+	const sessionDirty = await drainUntilIdleOrCap(drainSessionDirty, SESSION_DIRTY_CAP);
+	const gameProfileDirty = await drainUntilIdleOrCap(
+		drainGameProfileDirty,
+		GAME_PROFILE_DIRTY_CAP,
+	);
 
-		let srProcessed = 0;
-
-		while (srProcessed < SCORE_REDERIVE_CAP) {
-			// eslint-disable-next-line no-await-in-loop
-			const n = await drainScoreRederive();
-
-			if (n === 0) {
-				break;
-			}
-
-			srProcessed += n;
-			cycleMoved += n;
-		}
-
-		let pbProcessed = 0;
-
-		while (pbProcessed < PB_DIRTY_CAP) {
-			// eslint-disable-next-line no-await-in-loop
-			const n = await drainPbDirty();
-
-			if (n === 0) {
-				break;
-			}
-
-			pbProcessed += n;
-			cycleMoved += n;
-		}
-
-		let sessionProcessed = 0;
-
-		while (sessionProcessed < SESSION_DIRTY_CAP) {
-			// eslint-disable-next-line no-await-in-loop
-			const n = await drainSessionDirty();
-
-			if (n === 0) {
-				break;
-			}
-
-			sessionProcessed += n;
-			cycleMoved += n;
-		}
-
-		let gpProcessed = 0;
-
-		while (gpProcessed < GAME_PROFILE_DIRTY_CAP) {
-			// eslint-disable-next-line no-await-in-loop
-			const n = await drainGameProfileDirty();
-
-			if (n === 0) {
-				break;
-			}
-
-			gpProcessed += n;
-			cycleMoved += n;
-		}
-
-		if (cycleMoved === 0) {
-			break;
-		}
+	if (scoreRederive.capped || pbDirty.capped || sessionDirty.capped || gameProfileDirty.capped) {
+		log.info(
+			{
+				score_rederive: scoreRederive,
+				pb_dirty: pbDirty,
+				session_dirty: sessionDirty,
+				game_profile_dirty: gameProfileDirty,
+			},
+			"drainStatsQueuesInOrder: tick budget reached; any remaining rows will drain on a later tick",
+		);
 	}
 
 	const elapsedMs = Date.now() - tickStart;

--- a/typescript/server/src/lib/jobs/score-dirty-queues.test.ts
+++ b/typescript/server/src/lib/jobs/score-dirty-queues.test.ts
@@ -1,0 +1,137 @@
+import DB from "#services/pg/db";
+import { seedUser } from "#test-utils/pg-fixtures";
+import { describe, expect, it } from "vitest";
+
+function makeSongId(n: number): string {
+	return `SDQ_S${n.toString(16).padStart(20, "0")}`;
+}
+
+function makeChartId(n: number): string {
+	return `SDQ_C${n.toString(16).padStart(20, "0")}`;
+}
+
+function makeScoreId(n: number): string {
+	return `SDQ_SC${n.toString(16).padStart(20, "0")}`;
+}
+
+async function insertSongAndChart(n: number) {
+	const songId = makeSongId(n);
+	const chartId = makeChartId(n);
+
+	await DB.insertInto("song")
+		.values({
+			id: songId,
+			legacy_id: 9_300_000 + n,
+			game_group: "iidx",
+			title: `Dirty Queue Song ${n}`,
+			artist: "X",
+			search_terms: [],
+			alt_titles: [],
+			fts_document: "",
+			data: JSON.stringify({}),
+		})
+		.execute();
+
+	await DB.insertInto("chart")
+		.values({
+			id: chartId,
+			legacy_id: `dirty_queue_${n}`,
+			game: "iidx-sp",
+			song_id: songId,
+			level: "10",
+			level_num: 10,
+			is_primary: true,
+			difficulty: "ANOTHER",
+			versions: [],
+			data: JSON.stringify({ notecount: 100 }),
+		})
+		.execute();
+
+	return chartId;
+}
+
+function scoreRow(id: string, userId: number, chartId: string, sessionId: string | null) {
+	return {
+		id,
+		user_id: userId,
+		chart_id: chartId,
+		game: "iidx-sp" as const,
+		session_id: sessionId,
+		import_id: null,
+		data: JSON.stringify({}),
+		derived_data: JSON.stringify({}),
+		judgements: JSON.stringify({}),
+		calculated_data: JSON.stringify({}),
+		meta: JSON.stringify({}),
+		time_achieved: new Date().toISOString(),
+		time_added: new Date().toISOString(),
+		highlight: false,
+		comment: null,
+	};
+}
+
+describe("score dirty queue triggers", () => {
+	it("deduplicates dirty keys for batch score inserts", async () => {
+		const { id: userId } = await seedUser({ username: "dirty_queue_batch_user" });
+		const chartId = await insertSongAndChart(1);
+		const sessionId = "dirty-queue-session-batch";
+
+		await DB.insertInto("score")
+			.values([
+				scoreRow(makeScoreId(1), userId, chartId, sessionId),
+				scoreRow(makeScoreId(2), userId, chartId, sessionId),
+				scoreRow(makeScoreId(3), userId, chartId, sessionId),
+			])
+			.execute();
+
+		const pbRows = await DB.selectFrom("pb_dirty")
+			.selectAll()
+			.where("pb_dirty.user_id", "=", userId)
+			.where("pb_dirty.chart_id", "=", chartId)
+			.execute();
+		const sessionRows = await DB.selectFrom("session_dirty")
+			.selectAll()
+			.where("session_dirty.session_id", "=", sessionId)
+			.execute();
+		const profileRows = await DB.selectFrom("game_profile_dirty")
+			.selectAll()
+			.where("game_profile_dirty.user_id", "=", userId)
+			.where("game_profile_dirty.game", "=", "iidx-sp")
+			.execute();
+
+		expect(pbRows).toHaveLength(1);
+		expect(sessionRows).toHaveLength(1);
+		expect(profileRows).toHaveLength(1);
+	});
+
+	it("marks both old and new dirty keys when a score moves sessions", async () => {
+		const { id: userId } = await seedUser({ username: "dirty_queue_update_user" });
+		const chartId = await insertSongAndChart(2);
+		const oldSessionId = "dirty-queue-session-old";
+		const newSessionId = "dirty-queue-session-new";
+		const scoreId = makeScoreId(4);
+
+		await DB.insertInto("score")
+			.values(scoreRow(scoreId, userId, chartId, oldSessionId))
+			.execute();
+
+		await DB.deleteFrom("session_dirty")
+			.where("session_dirty.session_id", "in", [oldSessionId, newSessionId])
+			.execute();
+
+		await DB.updateTable("score")
+			.set({ session_id: newSessionId })
+			.where("score.id", "=", scoreId)
+			.execute();
+
+		const sessionRows = await DB.selectFrom("session_dirty")
+			.select("session_dirty.session_id")
+			.where("session_dirty.session_id", "in", [oldSessionId, newSessionId])
+			.orderBy("session_dirty.session_id")
+			.execute();
+
+		expect(sessionRows.map((row) => row.session_id)).toEqual(
+			[newSessionId, oldSessionId].sort(),
+		);
+	});
+});


### PR DESCRIPTION
Addresses #1630.

## Deep dive

The screenshot shows `drain_stats_queues` deadlocking inside the `enqueue_session_dirty()` trigger while PostgreSQL is inserting into `session_dirty` with `ON CONFLICT DO NOTHING`.

The deadlock comes from `drainScoreRederive()` processing multiple chart rederive jobs concurrently. Each job bulk-updates `score`, and the row-level score triggers enqueue `pb_dirty`, `session_dirty`, and `game_profile_dirty` rows as every score row is touched. When two chart transactions hit overlapping sessions/profiles in different score-row orders, `ON CONFLICT DO NOTHING` still waits on uncommitted unique-index entries, so the transactions can wait on each other.

## Fix

- Replace the score dirty-queue row-level triggers with statement-level transition-table triggers.
- Enqueue distinct dirty keys once per UPDATE/INSERT/DELETE statement and sort those keys before insertion, so overlapping transactions take unique-index locks in a deterministic order.
- Cover `pb_dirty`, `session_dirty`, and `game_profile_dirty`, including UPDATE cases where a score changes session or PB/profile identity.
- Keep the stats-queue cron bounded by draining each queue once per tick budget instead of repeatedly resetting per-queue caps inside an outer loop.

## Tests added

- Dirty-key dedupe for batched score inserts.
- Session move behavior marks both old and new sessions dirty.
- Tick-budget helper drains until empty or until the cap is reached.

## Verification

- `git diff --check` passed locally before commit.
- I could not run the Bun test suite in this Windows environment because Bun is not installed here and the installer download timed out. The patch is intentionally narrow and includes focused tests for the changed behavior.