### PR TITLE
Fix score dirty queue deadlock during rederive

### DIFF
--- a/db/migrations/20260604070000_statement_score_dirty_triggers.sql
+++ b/db/migrations/20260604070000_statement_score_dirty_triggers.sql
@@ -1,0 +1,132 @@
+-- Row-level dirty-queue triggers can deadlock during parallel score re-derivation.
+--
+-- `drainScoreRederive` updates many scores for several charts concurrently. When two
+-- charts share sessions, the old row trigger inserted into `session_dirty` one score at
+-- a time, so concurrent transactions could lock the same primary-key entries in
+-- different orders. Use statement-level transition tables instead: each score UPDATE
+-- statement inserts the distinct dirty keys once, in deterministic order.
+
+DROP TRIGGER IF EXISTS "score_session_dirty" ON score;
+DROP TRIGGER IF EXISTS "score_game_profile_dirty" ON score;
+
+CREATE OR REPLACE FUNCTION enqueue_session_dirty() RETURNS trigger AS $$
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		INSERT INTO session_dirty (session_id)
+		SELECT s.session_id
+		FROM (
+			SELECT DISTINCT si.session_id
+			FROM score_inserted AS si
+			WHERE
+				si.committed
+				AND si.session_id IS NOT NULL
+		) AS s
+		ORDER BY s.session_id
+		ON CONFLICT DO NOTHING;
+	ELSIF TG_OP = 'UPDATE' THEN
+		INSERT INTO session_dirty (session_id)
+		SELECT s.session_id
+		FROM (
+			SELECT suo.session_id
+			FROM score_updated_old AS suo
+			INNER JOIN score_updated_new AS sun ON sun.id = suo.id
+			WHERE
+				sun.committed
+				AND suo.session_id IS NOT NULL
+				AND suo.session_id IS DISTINCT FROM sun.session_id
+
+			UNION
+
+			SELECT sun.session_id
+			FROM score_updated_new AS sun
+			WHERE
+				sun.committed
+				AND sun.session_id IS NOT NULL
+		) AS s
+		ORDER BY s.session_id
+		ON CONFLICT DO NOTHING;
+	ELSIF TG_OP = 'DELETE' THEN
+		INSERT INTO session_dirty (session_id)
+		SELECT s.session_id
+		FROM (
+			SELECT DISTINCT sd.session_id
+			FROM score_deleted AS sd
+			WHERE
+				sd.committed
+				AND sd.session_id IS NOT NULL
+		) AS s
+		ORDER BY s.session_id
+		ON CONFLICT DO NOTHING;
+	END IF;
+
+	RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION enqueue_game_profile_dirty() RETURNS trigger AS $$
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		INSERT INTO game_profile_dirty (user_id, game)
+		SELECT g.user_id, g.game
+		FROM (
+			SELECT DISTINCT si.user_id, si.game
+			FROM score_inserted AS si
+			WHERE si.committed
+		) AS g
+		ORDER BY g.user_id, g.game
+		ON CONFLICT DO NOTHING;
+	ELSIF TG_OP = 'UPDATE' THEN
+		INSERT INTO game_profile_dirty (user_id, game)
+		SELECT g.user_id, g.game
+		FROM (
+			SELECT DISTINCT sun.user_id, sun.game
+			FROM score_updated_new AS sun
+			WHERE sun.committed
+		) AS g
+		ORDER BY g.user_id, g.game
+		ON CONFLICT DO NOTHING;
+	ELSIF TG_OP = 'DELETE' THEN
+		INSERT INTO game_profile_dirty (user_id, game)
+		SELECT g.user_id, g.game
+		FROM (
+			SELECT DISTINCT sd.user_id, sd.game
+			FROM score_deleted AS sd
+			WHERE sd.committed
+		) AS g
+		ORDER BY g.user_id, g.game
+		ON CONFLICT DO NOTHING;
+	END IF;
+
+	RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "score_session_dirty_ai"
+	AFTER INSERT ON score
+	REFERENCING NEW TABLE AS score_inserted
+	FOR EACH STATEMENT EXECUTE FUNCTION enqueue_session_dirty();
+
+CREATE TRIGGER "score_session_dirty_au"
+	AFTER UPDATE ON score
+	REFERENCING OLD TABLE AS score_updated_old NEW TABLE AS score_updated_new
+	FOR EACH STATEMENT EXECUTE FUNCTION enqueue_session_dirty();
+
+CREATE TRIGGER "score_session_dirty_ad"
+	AFTER DELETE ON score
+	REFERENCING OLD TABLE AS score_deleted
+	FOR EACH STATEMENT EXECUTE FUNCTION enqueue_session_dirty();
+
+CREATE TRIGGER "score_game_profile_dirty_ai"
+	AFTER INSERT ON score
+	REFERENCING NEW TABLE AS score_inserted
+	FOR EACH STATEMENT EXECUTE FUNCTION enqueue_game_profile_dirty();
+
+CREATE TRIGGER "score_game_profile_dirty_au"
+	AFTER UPDATE ON score
+	REFERENCING OLD TABLE AS score_updated_old NEW TABLE AS score_updated_new
+	FOR EACH STATEMENT EXECUTE FUNCTION enqueue_game_profile_dirty();
+
+CREATE TRIGGER "score_game_profile_dirty_ad"
+	AFTER DELETE ON score
+	REFERENCING OLD TABLE AS score_deleted
+	FOR EACH STATEMENT EXECUTE FUNCTION enqueue_game_profile_dirty();

--- a/typescript/server/src/lib/score-import/framework/pb/rederive-scores.recalc.test.ts
+++ b/typescript/server/src/lib/score-import/framework/pb/rederive-scores.recalc.test.ts
@@ -20,6 +20,7 @@ import { mongoScoreDataToPg, pgScoreDataToAPI } from "#lib/v3/migration-tools";
 import DB from "#services/pg/db";
 import { seedUser } from "#test-utils/pg-fixtures";
 import { Testing511Song, Testing511SPA } from "#test-utils/test-data";
+import { sql } from "kysely";
 import { type ChartDocument, type PgScoreData, type ScoreData } from "tachi-common";
 import { describe, expect, it } from "vitest";
 
@@ -533,6 +534,33 @@ describe("rederiveScoresForChart / chart checksum recalc (Postgres)", () => {
 
 	it("drainStatsQueuesInOrder completes with empty queues", async () => {
 		await drainStatsQueuesInOrder();
+	});
+
+	it("uses statement-level score dirty triggers for downstream queues", async () => {
+		const triggerNames = [
+			"score_session_dirty_ai",
+			"score_session_dirty_au",
+			"score_session_dirty_ad",
+			"score_game_profile_dirty_ai",
+			"score_game_profile_dirty_au",
+			"score_game_profile_dirty_ad",
+		];
+
+		const res = await sql<{ is_row_trigger: boolean; tgname: string }>`
+			SELECT
+				tgname,
+				((tgtype & 1) <> 0) AS is_row_trigger
+			FROM pg_trigger
+			WHERE
+				tgrelid = 'score'::regclass
+				AND tgname IN (${sql.join(triggerNames)})
+		`.execute(DB);
+
+		expect(res.rows).toHaveLength(6);
+
+		for (const row of res.rows) {
+			expect(row.is_row_trigger, row.tgname).toBe(false);
+		}
 	});
 
 	it("bulk-updates all scores on a multi-score chart correctly", async () => {

--- a/typescript/server/src/lib/score-import/framework/pb/rederive-scores.recalc.test.ts
+++ b/typescript/server/src/lib/score-import/framework/pb/rederive-scores.recalc.test.ts
@@ -134,12 +134,13 @@ async function insertIidxScore(opts: {
 async function insertIidxScoreN(opts: {
 	chartId: string;
 	scoreData: ScoreData<"iidx-sp">;
+	scoreId?: string;
 	sessionId?: string | null;
 	userId: number;
 }) {
 	const now = new Date().toISOString();
 	const { data, derived, judgements } = mongoScoreDataToPg("iidx-sp", opts.scoreData);
-	const scoreId = `sc-recalc-n-${opts.chartId}-${++insertIidxScoreCounter}`;
+	const scoreId = opts.scoreId ?? `sc-recalc-n-${opts.chartId}-${++insertIidxScoreCounter}`;
 
 	await DB.insertInto("score")
 		.values({
@@ -162,6 +163,62 @@ async function insertIidxScoreN(opts: {
 		.execute();
 
 	return scoreId;
+}
+
+async function insertIidxSession(opts: { id: string; name: string; userId: number }) {
+	const now = new Date().toISOString();
+
+	await DB.insertInto("session")
+		.values({
+			id: opts.id,
+			user_id: opts.userId,
+			game: "iidx-sp",
+			name: opts.name,
+			description: null,
+			time_inserted: now,
+			time_started: now,
+			time_ended: now,
+			calculated_data: JSON.stringify({}),
+			highlight: false,
+		})
+		.execute();
+}
+
+async function clearDirtyQueues() {
+	await DB.deleteFrom("score_rederive").execute();
+	await DB.deleteFrom("pb_dirty").execute();
+	await DB.deleteFrom("session_dirty").execute();
+	await DB.deleteFrom("game_profile_dirty").execute();
+}
+
+// Keeps the two score UPDATE statements overlapped long enough for the old row-level
+// dirty-queue triggers to lock the same session_dirty rows in opposite order.
+async function installScoreUpdateBarrier() {
+	await sql`DROP TRIGGER IF EXISTS "zz_test_score_update_barrier" ON score`.execute(DB);
+	await sql`DROP FUNCTION IF EXISTS _test_score_update_barrier()`.execute(DB);
+
+	await sql`
+		CREATE FUNCTION _test_score_update_barrier() RETURNS trigger AS $$
+		BEGIN
+			IF NEW.id LIKE 'sc-recalc-deadlock-%' THEN
+				PERFORM pg_sleep(0.25);
+			END IF;
+
+			RETURN NULL;
+		END;
+		$$ LANGUAGE plpgsql
+	`.execute(DB);
+
+	await sql`
+		CREATE TRIGGER "zz_test_score_update_barrier"
+			AFTER UPDATE ON score
+			FOR EACH ROW EXECUTE FUNCTION _test_score_update_barrier()
+	`.execute(DB);
+}
+
+async function uninstallScoreUpdateBarrier() {
+	await sql`DROP TRIGGER IF EXISTS "zz_test_score_update_barrier" ON score`.execute(DB);
+	await sql`DROP FUNCTION IF EXISTS _test_score_update_barrier()`.execute(DB);
 }
 
 function parseJsonb<T>(v: unknown): T {
@@ -534,6 +591,100 @@ describe("rederiveScoresForChart / chart checksum recalc (Postgres)", () => {
 
 	it("drainStatsQueuesInOrder completes with empty queues", async () => {
 		await drainStatsQueuesInOrder();
+	});
+
+	it("drainScoreRederive avoids dirty-queue deadlocks when parallel chart updates share sessions", async () => {
+		const n = ++recalcSeedCounter;
+		const { id: userA } = await seedUser({ username: `recalc_deadlock_a_${n}` });
+		const { id: userB } = await seedUser({ username: `recalc_deadlock_b_${n}` });
+		await seedIidxSpGameProfile(userA);
+		await seedIidxSpGameProfile(userB);
+
+		const sessionA = `sess-recalc-deadlock-a-${n}`;
+		const sessionB = `sess-recalc-deadlock-b-${n}`;
+
+		await insertIidxSession({
+			id: sessionA,
+			userId: userA,
+			name: "Recalc deadlock session A",
+		});
+		await insertIidxSession({
+			id: sessionB,
+			userId: userA,
+			name: "Recalc deadlock session B",
+		});
+
+		const chartA = `C_RECALC_DEADLOCK_A_${n}`;
+		const chartB = `C_RECALC_DEADLOCK_B_${n}`;
+		await insertSongAndChart(buildIidxSpChartDoc(chartA, `S_RECALC_DEADLOCK_A_${n}`, 10, 786));
+		await insertSongAndChart(buildIidxSpChartDoc(chartB, `S_RECALC_DEADLOCK_B_${n}`, 10, 786));
+
+		const scoreData = {
+			lamp: "CLEAR",
+			score: 1000,
+			grade: "AAA",
+			percent: 50,
+			optional: {},
+			judgements: { pgreat: 500, great: 0 },
+		} as ScoreData<"iidx-sp">;
+
+		await insertIidxScoreN({
+			chartId: chartA,
+			userId: userA,
+			sessionId: sessionA,
+			scoreData,
+			scoreId: `sc-recalc-deadlock-a-1-${n}`,
+		});
+		await insertIidxScoreN({
+			chartId: chartA,
+			userId: userA,
+			sessionId: sessionB,
+			scoreData,
+			scoreId: `sc-recalc-deadlock-a-2-${n}`,
+		});
+		await insertIidxScoreN({
+			chartId: chartB,
+			userId: userB,
+			sessionId: sessionB,
+			scoreData,
+			scoreId: `sc-recalc-deadlock-b-1-${n}`,
+		});
+		await insertIidxScoreN({
+			chartId: chartB,
+			userId: userB,
+			sessionId: sessionA,
+			scoreData,
+			scoreId: `sc-recalc-deadlock-b-2-${n}`,
+		});
+
+		await clearDirtyQueues();
+		await DB.insertInto("score_rederive")
+			.values([{ chart_id: chartA }, { chart_id: chartB }])
+			.execute();
+		await installScoreUpdateBarrier();
+
+		try {
+			const processedCharts = await drainScoreRederive();
+
+			expect(processedCharts).toBe(2);
+		} finally {
+			await uninstallScoreUpdateBarrier();
+		}
+
+		const queuedCharts = await DB.selectFrom("score_rederive")
+			.select(["score_rederive.chart_id"])
+			.where("score_rederive.chart_id", "in", [chartA, chartB])
+			.execute();
+
+		expect(queuedCharts).toHaveLength(0);
+
+		const dirtySessions = await DB.selectFrom("session_dirty")
+			.select(["session_dirty.session_id"])
+			.where("session_dirty.session_id", "in", [sessionA, sessionB])
+			.orderBy("session_dirty.session_id", "asc")
+			.execute();
+
+		expect(dirtySessions.map((r) => r.session_id)).toEqual([sessionA, sessionB]);
 	});
 
 	it("uses statement-level score dirty triggers for downstream queues", async () => {


### PR DESCRIPTION
Fixes #1630.

The deadlock is coming from the score dirty-queue triggers rather than from the leaderboard table directly. During score rederivation, several chart workers can update overlapping score/session sets at the same time. The old row-level `score_session_dirty` trigger inserted one `session_dirty` key per score row, so two transactions could take the same unique-index locks in different orders.

This changes the score dirty triggers to statement-level transition-table triggers. Each score INSERT/UPDATE/DELETE now inserts the distinct downstream dirty keys once, ordered deterministically before `ON CONFLICT DO NOTHING`. I applied the same pattern to `game_profile_dirty`, since it had the same row-level queueing shape.

Verification:
- Applied all migrations locally against the test Postgres, including `20260604070000_statement_score_dirty_triggers`.
- Ran `vitest run src/lib/score-import/framework/pb/rederive-scores.recalc.test.ts`: 12 tests passed.