### PR TITLE
fix: remove level from FormatDifficultySearch

### DIFF
--- a/typescript/common/src/utils/util.ts
+++ b/typescript/common/src/utils/util.ts
@@ -112,7 +112,7 @@ export function FormatDifficultySearch(chart: ChartDocument): string | null {
 	const gameConfig = GetGameConfig(chart.game);
 
 	if (["bms", "itg", "pms"].includes(gameGroup)) {
-		return "";
+		return null;
 	}
 
 	let diff: string | undefined;

--- a/typescript/common/src/utils/util.ts
+++ b/typescript/common/src/utils/util.ts
@@ -108,7 +108,22 @@ function FormatDifficultyInternal(chart: ChartDocument, short: boolean): string 
  * Formats a chart's difficulty for searching, such as forwarding this query to youtube.
  */
 export function FormatDifficultySearch(chart: ChartDocument): string | null {
-	return FormatDifficultyLong(chart);
+	const gameGroup = GameToGameGroup(chart.game);
+	const gameConfig = GetGameConfig(chart.game);
+
+	if (["bms", "itg", "pms"].includes(gameGroup)) {
+		return "";
+	}
+
+	let diff: string | undefined;
+	if (
+		gameConfig.difficulties.type === "FIXED" ||
+		gameConfig.difficulties.type === "CHUGEKIMAI_STYLE"
+	) {
+		diff = gameConfig.difficulties.formatLong[chart.difficulty];
+	}
+	diff ??= chart.difficulty;
+	return diff.trim();
 }
 
 export function FormatGame(game: V3Game): string {


### PR DESCRIPTION
Change `FormatDifficultySearch` from an alias of `FormatDifficultyLong` to a simpler variant thereof, without the level value.