### PR TITLE
add NBL to SDVX_INF_DIFFS + add altTitles

### DIFF
--- a/db/seeds/songs-sdvx.json
+++ b/db/seeds/songs-sdvx.json
@@ -8445,7 +8445,9 @@
 		"title": "無双"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"ロンロンへ ライライライ！"
+		],
 		"artist": "ここなつ",
 		"data": {
 			"displayVersion": "gw"
@@ -18821,7 +18823,9 @@
 		"title": "#EmoCloche"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"cloche(といぼっくすうぃんぐ みっくす)"
+		],
 		"artist": "coTatsu",
 		"data": {
 			"displayVersion": "vivid"
@@ -22034,7 +22038,9 @@
 		"title": "ユメブキ"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"カジノファイヤーことみちゃん(ARM feat. 山本椛 + Brasscapsule)"
+		],
 		"artist": "ARM feat. 山本椛 + Brasscapsule",
 		"data": {
 			"displayVersion": "exceed"
@@ -27885,7 +27891,9 @@
 		"title": "SCHWARZSCHILD FIELD"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"ビューティフル レシート"
+		],
 		"artist": "Lucky Vacuum",
 		"data": {
 			"displayVersion": "exceed"

--- a/typescript/server/src/utils/queries/charts.ts
+++ b/typescript/server/src/utils/queries/charts.ts
@@ -582,12 +582,12 @@ export async function FindIIDXChartWith2DXtraHash(hash: string) {
 	return ToChartDocument(row);
 }
 
-const SDVX_INF_DIFFS = ["INF", "GRV", "HVN", "VVD", "XCD"] as const;
+const SDVX_INF_DIFFS = ["INF", "GRV", "HVN", "VVD", "XCD", "NBL"] as const;
 
 /**
  * Find an SDVX Chart on its in game ID. This exists to handle
  * oddities with SDVX difficulties - If "ANY_INF" is sent, it actually
- * refers to any of INF, GRV, HVN or VVD. This is because some services treat
+ * refers to any of INF, GRV, HVN, VVD, XCD, or NBL. This is because some services treat
  * all of those as the same difficulty, but we do not.
  */
 export async function FindSDVXChartOnInGameID(


### PR DESCRIPTION
This adds NBL to the list of difficulties that is accepted under ANY_INF. This will ensure ANY_INF imports on NBL charts succeed (Mikado uses this).

I also added altTitles for every other eAmusement CSV import error that I could find post-Nabla update.