### PR TITLE
Add an extra case in set rivals for empty rival list

### DIFF
--- a/typescript/server/src/lib/rivals/rivals.ts
+++ b/typescript/server/src/lib/rivals/rivals.ts
@@ -95,6 +95,17 @@ export async function setRivalsWithResult(
 	game: V3Game,
 	newRivals: Array<integer>,
 ): Promise<SetRivalsFailReasons | null> {
+	if (newRivals.length === 0) {
+		await DB.deleteFrom("game_rival")
+			.where("user_id", "=", userID)
+			.where("game", "=", game)
+			.execute();
+
+		await UpdatePlayersRivalRankings(userID, game);
+
+		return null;
+	}
+
 	if (newRivals.length > ServerConfig.MAX_RIVALS) {
 		return SetRivalsFailReasons.TOO_MANY;
 	}


### PR DESCRIPTION
in the sql that gets the count of game profiles, postgres throws an exception when an in clause has an empty array.

makes most sense to just skip all that logic and delete all rivals if the list is empty and have an early exit.

does the UpdatePlayersRivalRankings need to be there when rival list is empty? i presume something needs updating so i put it there 