### PR TITLE
fix: dynamic baseline for ongeki score graphs

### DIFF
--- a/db/seeds/charts-iidx-dp.json
+++ b/db/seeds/charts-iidx-dp.json
@@ -73,6 +73,468 @@
 			"2dxtraSet": null,
 			"bpiCoefficient": null,
 			"hashSHA256": null,
+			"inGameID": 33094,
+			"kaidenAverage": null,
+			"notecount": 1109,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C195e9b961c20f6c099a",
+		"isPrimary": true,
+		"legacyChartID": "08f2cd3c194a319eb6a1d90dbeb254f29dbf76b3",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S191de0bc75be28bf112",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33094,
+			"kaidenAverage": null,
+			"notecount": 693,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19f1e7a6eef84f5a861",
+		"isPrimary": true,
+		"legacyChartID": "1b0c0923d2533104936b2f6bf5dc3529d70f97d3",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S191de0bc75be28bf112",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33094,
+			"kaidenAverage": null,
+			"notecount": 402,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C196ffea2b4f4fdc38b5",
+		"isPrimary": true,
+		"legacyChartID": "d333cad151bbeae62cec2862bb692bf30111527f",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S191de0bc75be28bf112",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33117,
+			"kaidenAverage": null,
+			"notecount": 1669,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C196f0be9b5195120c46",
+		"isPrimary": true,
+		"legacyChartID": "6391846f7d939fd755f2667054fd6c550eb223ce",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S1920f6348d8557a1085",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33117,
+			"kaidenAverage": null,
+			"notecount": 1060,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C1983332275bab63641d",
+		"isPrimary": true,
+		"legacyChartID": "47463d6549273e7c9f8a86c0b60553a24f47280e",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S1920f6348d8557a1085",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33117,
+			"kaidenAverage": null,
+			"notecount": 655,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C194f9798d5b93aa29b6",
+		"isPrimary": true,
+		"legacyChartID": "ae03453e20a67d4b0a2444eb68a533ee69bae35e",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S1920f6348d8557a1085",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33119,
+			"kaidenAverage": null,
+			"notecount": 1140,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19a46b353d2838f26fc",
+		"isPrimary": true,
+		"legacyChartID": "1b9624efad15aac54ce4f8baa98b443f710155da",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19251aaf95d83b22774",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33119,
+			"kaidenAverage": null,
+			"notecount": 777,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C191b5689fea5f551fe3",
+		"isPrimary": true,
+		"legacyChartID": "918ee8f4412d21a0f6a04c5613babbb895f4aba7",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19251aaf95d83b22774",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33119,
+			"kaidenAverage": null,
+			"notecount": 501,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19be97eb577fba94967",
+		"isPrimary": true,
+		"legacyChartID": "a0fd4059707a39d55758b4b224cfd7169941a4b0",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19251aaf95d83b22774",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33087,
+			"kaidenAverage": null,
+			"notecount": 1559,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19b1b367ea6c9c8b458",
+		"isPrimary": true,
+		"legacyChartID": "750dc3cf0ca5e68a87da4cb826c0e645beb27e28",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S193608b356794611ada",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33087,
+			"kaidenAverage": null,
+			"notecount": 956,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19ce6fe95fef747d78d",
+		"isPrimary": true,
+		"legacyChartID": "82e1e4ec428c8d2492951cb8ae2633b21c4bf8d4",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S193608b356794611ada",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33087,
+			"kaidenAverage": null,
+			"notecount": 556,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C1921b9765a58132cd26",
+		"isPrimary": true,
+		"legacyChartID": "5c2d08246e535f652aba668efa3daaa5fe6ed7c4",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S193608b356794611ada",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33116,
+			"kaidenAverage": null,
+			"notecount": 1101,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19d3079ffad964a56b8",
+		"isPrimary": true,
+		"legacyChartID": "66bcfa32b859a5f090319b3113182e877cc04a9f",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19418561db2805a0592",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33116,
+			"kaidenAverage": null,
+			"notecount": 829,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19e1ba6260a46fabe51",
+		"isPrimary": true,
+		"legacyChartID": "303d42cf59aa185e18ccf3d2e3c6754670f822dd",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19418561db2805a0592",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33116,
+			"kaidenAverage": null,
+			"notecount": 404,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C1977ecafe40565627d5",
+		"isPrimary": true,
+		"legacyChartID": "61f8b0f05808f21fafa38f5a4003fc5671d014fa",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19418561db2805a0592",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33092,
+			"kaidenAverage": null,
+			"notecount": 1505,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C197953d9688cf2cca79",
+		"isPrimary": true,
+		"legacyChartID": "f6244f9271416456e3b0092190adb0dfc9669b7e",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S195b41082f57a270a83",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33092,
+			"kaidenAverage": null,
+			"notecount": 1067,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C1959a4c5c3b3cc7469c",
+		"isPrimary": true,
+		"legacyChartID": "58d4d20e52c5a4833caef4e7c8f513a603564dee",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S195b41082f57a270a83",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33092,
+			"kaidenAverage": null,
+			"notecount": 535,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19ce2c32d9a3ba921f0",
+		"isPrimary": true,
+		"legacyChartID": "b73b7ea4d9a3a3b3fe5fa07b911b4003f1c0c903",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S195b41082f57a270a83",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33089,
+			"kaidenAverage": null,
+			"notecount": 1751,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19cdac4cb35e71f6412",
+		"isPrimary": true,
+		"legacyChartID": "a34310c3ac27af0898a8073e7037808bda5c8f5a",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S1966940525062bf23cb",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33089,
+			"kaidenAverage": null,
+			"notecount": 1176,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19ee31806ff1e699538",
+		"isPrimary": true,
+		"legacyChartID": "afb609ba12d8ab3c85198b9f2f1d24715c47f3d5",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S1966940525062bf23cb",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33089,
+			"kaidenAverage": null,
+			"notecount": 538,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C1968293f46ae9f6602a",
+		"isPrimary": true,
+		"legacyChartID": "1366074c056da4ed85e491f39b0d631d60ac23ff",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S1966940525062bf23cb",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
 			"inGameID": [
 				80111
 			],
@@ -280,6 +742,270 @@
 			"2dxtraSet": null,
 			"bpiCoefficient": null,
 			"hashSHA256": null,
+			"inGameID": 33093,
+			"kaidenAverage": null,
+			"notecount": 1552,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19e81b0a63c464b153d",
+		"isPrimary": true,
+		"legacyChartID": "652d5abd913143d7b97878ef1ee851915dc7d676",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S198323427fea95b582f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33093,
+			"kaidenAverage": null,
+			"notecount": 1057,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C199eb9c04e19780d1a5",
+		"isPrimary": true,
+		"legacyChartID": "ec1fee09e85cd538ad7cc7aa8bca30f9c1f62a1a",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S198323427fea95b582f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33093,
+			"kaidenAverage": null,
+			"notecount": 581,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19a894671560a7a52f5",
+		"isPrimary": true,
+		"legacyChartID": "d255bd8bcbe2d85e3869a03c98e9c2394ffb51d8",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S198323427fea95b582f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33088,
+			"kaidenAverage": null,
+			"notecount": 1305,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C1985e2e6e1c82e7a320",
+		"isPrimary": true,
+		"legacyChartID": "0208e32e2cc7212291357e5fd4832488471c0566",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19858e92318551cd3f9",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33088,
+			"kaidenAverage": null,
+			"notecount": 904,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19502b62820c91e2359",
+		"isPrimary": true,
+		"legacyChartID": "470d2462814ca6f817e90d48594df826c63e9546",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19858e92318551cd3f9",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33088,
+			"kaidenAverage": null,
+			"notecount": 389,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C190f624ea47d0976a6a",
+		"isPrimary": true,
+		"legacyChartID": "b9e67ee1e489ca29f66586f0cabaaa7b1b250465",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19858e92318551cd3f9",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33121,
+			"kaidenAverage": null,
+			"notecount": 1547,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19cedfaa3695e09810f",
+		"isPrimary": true,
+		"legacyChartID": "1586d82bd5458146768161676d84d42484a6c6ba",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S1990f414129cbbe810d",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33121,
+			"kaidenAverage": null,
+			"notecount": 1038,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C1983bebbca0af10fb9b",
+		"isPrimary": true,
+		"legacyChartID": "71f0adc7c27ef09467882711b8f6863ef65a64dd",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S1990f414129cbbe810d",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33121,
+			"kaidenAverage": null,
+			"notecount": 647,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C191af565dc10f3d0944",
+		"isPrimary": true,
+		"legacyChartID": "7be4790ae787fc7996eb562682406e0b4dc8f05b",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S1990f414129cbbe810d",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33090,
+			"kaidenAverage": null,
+			"notecount": 1154,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C193233f4a1e71800d5c",
+		"isPrimary": true,
+		"legacyChartID": "19e629f17683c0f9957d0522dc466a27f0d5ba4e",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19942cd2d4bb159f3cd",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33090,
+			"kaidenAverage": null,
+			"notecount": 770,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C193250207ca90ee3ffe",
+		"isPrimary": true,
+		"legacyChartID": "8881e15a3be36127de3353341919c17ab08157a2",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19942cd2d4bb159f3cd",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33090,
+			"kaidenAverage": null,
+			"notecount": 464,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C194133ea5f62edd9f12",
+		"isPrimary": true,
+		"legacyChartID": "c1c443d72026d7b3ee2d88fbf7d30eef30566ece",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19942cd2d4bb159f3cd",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
 			"inGameID": [
 				80109
 			],
@@ -341,6 +1067,204 @@
 		"levelNum": 5,
 		"songID": "S19a282b7e4c2933820b",
 		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33115,
+			"kaidenAverage": null,
+			"notecount": 1246,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19dd63800b4c4890872",
+		"isPrimary": true,
+		"legacyChartID": "1a6d6a4fc65777b6c1f2950b0cfb65965894af57",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19a9fc151bbcaf0cd7c",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33115,
+			"kaidenAverage": null,
+			"notecount": 935,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19e28fe03ba72600902",
+		"isPrimary": true,
+		"legacyChartID": "ec4a24e8377e0b6231028bf7bbbf596611087c4f",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19a9fc151bbcaf0cd7c",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33115,
+			"kaidenAverage": null,
+			"notecount": 545,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19c0f9ec8c157c7b068",
+		"isPrimary": true,
+		"legacyChartID": "15169e39162d8b0bd9bdd610819e21a4d71e9d2c",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19a9fc151bbcaf0cd7c",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33120,
+			"kaidenAverage": null,
+			"notecount": 1511,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C195a851b57d12ef0f6d",
+		"isPrimary": true,
+		"legacyChartID": "89e53e0234bd717722df387aaba0393c12ff4b67",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19bd502dae9343e2f7f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33120,
+			"kaidenAverage": null,
+			"notecount": 961,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19e0355cbc80fa3ac18",
+		"isPrimary": true,
+		"legacyChartID": "05707149c85dbe245a86d97384cc2cbbf6b6cc29",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19bd502dae9343e2f7f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33120,
+			"kaidenAverage": null,
+			"notecount": 605,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19fe5e017d2b3914be7",
+		"isPrimary": true,
+		"legacyChartID": "a9eb7d38179a5dd560f191608dca0c57d118c730",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19bd502dae9343e2f7f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33091,
+			"kaidenAverage": null,
+			"notecount": 1767,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19ab2413bd9e49a6648",
+		"isPrimary": true,
+		"legacyChartID": "e5237062a715755b071c7b9268c8d6c4ea41f05c",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19beaf6181b5eb809e6",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33091,
+			"kaidenAverage": null,
+			"notecount": 1183,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19c4cbc9ced9b3d182a",
+		"isPrimary": true,
+		"legacyChartID": "0bf66a85b8fd30cf9e4864d90c41418f13acbf24",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19beaf6181b5eb809e6",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33091,
+			"kaidenAverage": null,
+			"notecount": 599,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19379bc1855621c9712",
+		"isPrimary": true,
+		"legacyChartID": "16278d066274e4759ea11bbfff6caccc1d008894",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19beaf6181b5eb809e6",
+		"versions": [
+			"33",
 			"inf"
 		]
 	},
@@ -157714,6 +158638,27 @@
 			"hashSHA256": null,
 			"inGameID": 22007,
 			"kaidenAverage": null,
+			"notecount": 1936,
+			"worldRecord": null
+		},
+		"difficulty": "LEGGENDARIA",
+		"id": "C1911dedd97e5167bad1",
+		"isPrimary": true,
+		"legacyChartID": "0971d0d78f05a9b7fa4a4aed440ea6206ff540e0",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19d35e0b3e0c8277500",
+		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 22007,
+			"kaidenAverage": null,
 			"notecount": 467,
 			"worldRecord": null
 		},
@@ -157750,27 +158695,6 @@
 			"33",
 			"32-omni"
 		]
-	},
-	{
-  		"data": {
-    		"2dxtraSet": null,
-    		"bpiCoefficient": null,
-    		"hashSHA256": null,
-    		"inGameID": 22007,
-    	"kaidenAverage": null,
-    	"notecount": 1936,
-    	"worldRecord": null
-  		},
-  		"difficulty": "LEGGENDARIA",
-  		"id": "C1911dedd97e5167bad1",
-  		"isPrimary": true,
-  		"legacyChartID": "0971d0d78f05a9b7fa4a4aed440ea6206ff540e0",
-  		"level": "12",
-  		"levelNum": 12,
-  		"songID": "S19d35e0b3e0c8277500",
-  		"versions": [
-    		"inf"
-  		]
 	},
 	{
 		"data": {
@@ -218574,6 +219498,27 @@
 			"hashSHA256": null,
 			"inGameID": 25070,
 			"kaidenAverage": null,
+			"notecount": 1481,
+			"worldRecord": null
+		},
+		"difficulty": "LEGGENDARIA",
+		"id": "C1973d63a5c0d9fa858a",
+		"isPrimary": true,
+		"legacyChartID": "0df58c69a1dbfd7c8e8fccfc2f1ffa0846d0ac40",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19d35e0b5d049d6aa1b",
+		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 25070,
+			"kaidenAverage": null,
 			"notecount": 503,
 			"worldRecord": null
 		},
@@ -218607,27 +219552,6 @@
 			"33",
 			"32-omni"
 		]
-	},
-	{
-  		"data": {
-    		"2dxtraSet": null,
-    		"bpiCoefficient": null,
-    		"hashSHA256": null,
-    		"inGameID": 25070,
-    		"kaidenAverage": null,
-    		"notecount": 1481,
-    		"worldRecord": null
-  		},
-  		"difficulty": "LEGGENDARIA",
-  		"id": "C1973d63a5c0d9fa858a",
-  		"isPrimary": true,
-  		"legacyChartID": "0df58c69a1dbfd7c8e8fccfc2f1ffa0846d0ac40",
-  		"level": "11",
-  		"levelNum": 11,
-  		"songID": "S19d35e0b5d049d6aa1b",
-  		"versions": [
-    		"inf"
-  		]
 	},
 	{
 		"data": {
@@ -235655,6 +236579,27 @@
 			"hashSHA256": null,
 			"inGameID": 27100,
 			"kaidenAverage": null,
+			"notecount": 1250,
+			"worldRecord": null
+		},
+		"difficulty": "LEGGENDARIA",
+		"id": "C190750662dd7fb1d9e9",
+		"isPrimary": true,
+		"legacyChartID": "37fae171fcde4a7326314c6517462a291b2fc066",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19d35e0b659807e9b23",
+		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 27100,
+			"kaidenAverage": null,
 			"notecount": 394,
 			"worldRecord": null
 		},
@@ -235685,27 +236630,6 @@
 			"33",
 			"32-omni"
 		]
-	},
-	{
-  		"data": {
-    		"2dxtraSet": null,
-    		"bpiCoefficient": null,
-    		"hashSHA256": null,
-    		"inGameID": 27100,
-    		"kaidenAverage": null,
-    		"notecount": 1250,
-    		"worldRecord": null
-  			},
-  		"difficulty": "LEGGENDARIA",
-  		"id": "C190750662dd7fb1d9e9",
-  		"isPrimary": true,
-  		"legacyChartID": "37fae171fcde4a7326314c6517462a291b2fc066",
-  		"level": "12",
-  		"levelNum": 12,
-  		"songID": "S19d35e0b659807e9b23",
-  		"versions": [
-    		"inf"
-  		]
 	},
 	{
 		"data": {
@@ -265472,6 +266396,30 @@
 				30228
 			],
 			"kaidenAverage": null,
+			"notecount": 1537,
+			"worldRecord": null
+		},
+		"difficulty": "LEGGENDARIA",
+		"id": "C19b845223b07dcebcda",
+		"isPrimary": true,
+		"legacyChartID": "690616c2d0d1d9b8914ee6e6e8646deebbeff015",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19d35e0b773a019cfe0",
+		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": [
+				80028,
+				30228
+			],
+			"kaidenAverage": null,
 			"notecount": 469,
 			"worldRecord": null
 		},
@@ -265488,30 +266436,6 @@
 			"31-2dxtra",
 			"32-omni"
 		]
-	},
-	{
-  		"data": {
-    		"2dxtraSet": null,
-    		"bpiCoefficient": null,
-    		"hashSHA256": null,
-    		"inGameID": [
-      			80028,
-      			30228
-    		],
-    		"kaidenAverage": null,
-    		"notecount": 1537,
-    		"worldRecord": null
-  		},
-  		"difficulty": "LEGGENDARIA",
-  		"id": "C19b845223b07dcebcda",
-  		"isPrimary": true,
-  		"legacyChartID": "690616c2d0d1d9b8914ee6e6e8646deebbeff015",
-  		"level": "11",
-  		"levelNum": 11,
-  		"songID": "S19d35e0b773a019cfe0",
-  		"versions": [
-    		"inf"
-  		]
 	},
 	{
 		"data": {
@@ -295035,6 +295959,72 @@
 		"levelNum": 4,
 		"songID": "S19d35e0b8f12116f6da",
 		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33118,
+			"kaidenAverage": null,
+			"notecount": 1411,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C1949e0c110e94f46e17",
+		"isPrimary": true,
+		"legacyChartID": "a2146b790ecb40498e988b7948c221235ea83b4c",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19dd4acb6dc336ea454",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33118,
+			"kaidenAverage": null,
+			"notecount": 878,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19f2276139656b3aaee",
+		"isPrimary": true,
+		"legacyChartID": "82ad08250cdfbbc6261c76467990bef40ed33929",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19dd4acb6dc336ea454",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33118,
+			"kaidenAverage": null,
+			"notecount": 580,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19b9bf9adb382d25120",
+		"isPrimary": true,
+		"legacyChartID": "b6aa4d1c84f9b5e893c9fefc8e2af1c75ae41bb2",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19dd4acb6dc336ea454",
+		"versions": [
+			"33",
 			"inf"
 		]
 	},
@@ -791602,996 +792592,5 @@
 		"versions": [
 			"31-2dxtra"
 		]
-	},
-	{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33087,
-    "kaidenAverage": null,
-    "notecount": 556,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C1921b9765a58132cd26",
-  "isPrimary": true,
-  "legacyChartID": "5c2d08246e535f652aba668efa3daaa5fe6ed7c4",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S193608b356794611ada",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33087,
-    "kaidenAverage": null,
-    "notecount": 956,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19ce6fe95fef747d78d",
-  "isPrimary": true,
-  "legacyChartID": "82e1e4ec428c8d2492951cb8ae2633b21c4bf8d4",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S193608b356794611ada",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33087,
-    "kaidenAverage": null,
-    "notecount": 1559,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19b1b367ea6c9c8b458",
-  "isPrimary": true,
-  "legacyChartID": "750dc3cf0ca5e68a87da4cb826c0e645beb27e28",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S193608b356794611ada",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33088,
-    "kaidenAverage": null,
-    "notecount": 389,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C190f624ea47d0976a6a",
-  "isPrimary": true,
-  "legacyChartID": "b9e67ee1e489ca29f66586f0cabaaa7b1b250465",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S19858e92318551cd3f9",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33088,
-    "kaidenAverage": null,
-    "notecount": 904,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19502b62820c91e2359",
-  "isPrimary": true,
-  "legacyChartID": "470d2462814ca6f817e90d48594df826c63e9546",
-  "level": "8",
-  "levelNum": 8,
-  "songID": "S19858e92318551cd3f9",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33088,
-    "kaidenAverage": null,
-    "notecount": 1305,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C1985e2e6e1c82e7a320",
-  "isPrimary": true,
-  "legacyChartID": "0208e32e2cc7212291357e5fd4832488471c0566",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19858e92318551cd3f9",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33089,
-    "kaidenAverage": null,
-    "notecount": 538,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C1968293f46ae9f6602a",
-  "isPrimary": true,
-  "legacyChartID": "1366074c056da4ed85e491f39b0d631d60ac23ff",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S1966940525062bf23cb",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33089,
-    "kaidenAverage": null,
-    "notecount": 1176,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19ee31806ff1e699538",
-  "isPrimary": true,
-  "legacyChartID": "afb609ba12d8ab3c85198b9f2f1d24715c47f3d5",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S1966940525062bf23cb",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33089,
-    "kaidenAverage": null,
-    "notecount": 1751,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19cdac4cb35e71f6412",
-  "isPrimary": true,
-  "legacyChartID": "a34310c3ac27af0898a8073e7037808bda5c8f5a",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S1966940525062bf23cb",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33090,
-    "kaidenAverage": null,
-    "notecount": 464,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C194133ea5f62edd9f12",
-  "isPrimary": true,
-  "legacyChartID": "c1c443d72026d7b3ee2d88fbf7d30eef30566ece",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S19942cd2d4bb159f3cd",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33090,
-    "kaidenAverage": null,
-    "notecount": 770,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C193250207ca90ee3ffe",
-  "isPrimary": true,
-  "legacyChartID": "8881e15a3be36127de3353341919c17ab08157a2",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S19942cd2d4bb159f3cd",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33090,
-    "kaidenAverage": null,
-    "notecount": 1154,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C193233f4a1e71800d5c",
-  "isPrimary": true,
-  "legacyChartID": "19e629f17683c0f9957d0522dc466a27f0d5ba4e",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19942cd2d4bb159f3cd",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33091,
-    "kaidenAverage": null,
-    "notecount": 599,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19379bc1855621c9712",
-  "isPrimary": true,
-  "legacyChartID": "16278d066274e4759ea11bbfff6caccc1d008894",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S19beaf6181b5eb809e6",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33091,
-    "kaidenAverage": null,
-    "notecount": 1183,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19c4cbc9ced9b3d182a",
-  "isPrimary": true,
-  "legacyChartID": "0bf66a85b8fd30cf9e4864d90c41418f13acbf24",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19beaf6181b5eb809e6",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33091,
-    "kaidenAverage": null,
-    "notecount": 1767,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19ab2413bd9e49a6648",
-  "isPrimary": true,
-  "legacyChartID": "e5237062a715755b071c7b9268c8d6c4ea41f05c",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S19beaf6181b5eb809e6",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33092,
-    "kaidenAverage": null,
-    "notecount": 535,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19ce2c32d9a3ba921f0",
-  "isPrimary": true,
-  "legacyChartID": "b73b7ea4d9a3a3b3fe5fa07b911b4003f1c0c903",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S195b41082f57a270a83",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33092,
-    "kaidenAverage": null,
-    "notecount": 1067,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C1959a4c5c3b3cc7469c",
-  "isPrimary": true,
-  "legacyChartID": "58d4d20e52c5a4833caef4e7c8f513a603564dee",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S195b41082f57a270a83",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33092,
-    "kaidenAverage": null,
-    "notecount": 1505,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C197953d9688cf2cca79",
-  "isPrimary": true,
-  "legacyChartID": "f6244f9271416456e3b0092190adb0dfc9669b7e",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S195b41082f57a270a83",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33093,
-    "kaidenAverage": null,
-    "notecount": 581,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19a894671560a7a52f5",
-  "isPrimary": true,
-  "legacyChartID": "d255bd8bcbe2d85e3869a03c98e9c2394ffb51d8",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S198323427fea95b582f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33093,
-    "kaidenAverage": null,
-    "notecount": 1057,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C199eb9c04e19780d1a5",
-  "isPrimary": true,
-  "legacyChartID": "ec1fee09e85cd538ad7cc7aa8bca30f9c1f62a1a",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S198323427fea95b582f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33093,
-    "kaidenAverage": null,
-    "notecount": 1552,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19e81b0a63c464b153d",
-  "isPrimary": true,
-  "legacyChartID": "652d5abd913143d7b97878ef1ee851915dc7d676",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S198323427fea95b582f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33094,
-    "kaidenAverage": null,
-    "notecount": 402,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C196ffea2b4f4fdc38b5",
-  "isPrimary": true,
-  "legacyChartID": "d333cad151bbeae62cec2862bb692bf30111527f",
-  "level": "4",
-  "levelNum": 4,
-  "songID": "S191de0bc75be28bf112",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33094,
-    "kaidenAverage": null,
-    "notecount": 693,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19f1e7a6eef84f5a861",
-  "isPrimary": true,
-  "legacyChartID": "1b0c0923d2533104936b2f6bf5dc3529d70f97d3",
-  "level": "7",
-  "levelNum": 7,
-  "songID": "S191de0bc75be28bf112",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33094,
-    "kaidenAverage": null,
-    "notecount": 1109,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C195e9b961c20f6c099a",
-  "isPrimary": true,
-  "legacyChartID": "08f2cd3c194a319eb6a1d90dbeb254f29dbf76b3",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S191de0bc75be28bf112",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33115,
-    "kaidenAverage": null,
-    "notecount": 545,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19c0f9ec8c157c7b068",
-  "isPrimary": true,
-  "legacyChartID": "15169e39162d8b0bd9bdd610819e21a4d71e9d2c",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S19a9fc151bbcaf0cd7c",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33115,
-    "kaidenAverage": null,
-    "notecount": 935,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19e28fe03ba72600902",
-  "isPrimary": true,
-  "legacyChartID": "ec4a24e8377e0b6231028bf7bbbf596611087c4f",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S19a9fc151bbcaf0cd7c",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33115,
-    "kaidenAverage": null,
-    "notecount": 1246,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19dd63800b4c4890872",
-  "isPrimary": true,
-  "legacyChartID": "1a6d6a4fc65777b6c1f2950b0cfb65965894af57",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S19a9fc151bbcaf0cd7c",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33116,
-    "kaidenAverage": null,
-    "notecount": 404,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C1977ecafe40565627d5",
-  "isPrimary": true,
-  "legacyChartID": "61f8b0f05808f21fafa38f5a4003fc5671d014fa",
-  "level": "4",
-  "levelNum": 4,
-  "songID": "S19418561db2805a0592",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33116,
-    "kaidenAverage": null,
-    "notecount": 829,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19e1ba6260a46fabe51",
-  "isPrimary": true,
-  "legacyChartID": "303d42cf59aa185e18ccf3d2e3c6754670f822dd",
-  "level": "8",
-  "levelNum": 8,
-  "songID": "S19418561db2805a0592",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33116,
-    "kaidenAverage": null,
-    "notecount": 1101,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19d3079ffad964a56b8",
-  "isPrimary": true,
-  "legacyChartID": "66bcfa32b859a5f090319b3113182e877cc04a9f",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19418561db2805a0592",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33117,
-    "kaidenAverage": null,
-    "notecount": 655,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C194f9798d5b93aa29b6",
-  "isPrimary": true,
-  "legacyChartID": "ae03453e20a67d4b0a2444eb68a533ee69bae35e",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S1920f6348d8557a1085",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33117,
-    "kaidenAverage": null,
-    "notecount": 1060,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C1983332275bab63641d",
-  "isPrimary": true,
-  "legacyChartID": "47463d6549273e7c9f8a86c0b60553a24f47280e",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S1920f6348d8557a1085",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33117,
-    "kaidenAverage": null,
-    "notecount": 1669,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C196f0be9b5195120c46",
-  "isPrimary": true,
-  "legacyChartID": "6391846f7d939fd755f2667054fd6c550eb223ce",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S1920f6348d8557a1085",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33118,
-    "kaidenAverage": null,
-    "notecount": 580,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19b9bf9adb382d25120",
-  "isPrimary": true,
-  "legacyChartID": "b6aa4d1c84f9b5e893c9fefc8e2af1c75ae41bb2",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S19dd4acb6dc336ea454",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33118,
-    "kaidenAverage": null,
-    "notecount": 878,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19f2276139656b3aaee",
-  "isPrimary": true,
-  "legacyChartID": "82ad08250cdfbbc6261c76467990bef40ed33929",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S19dd4acb6dc336ea454",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33118,
-    "kaidenAverage": null,
-    "notecount": 1411,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C1949e0c110e94f46e17",
-  "isPrimary": true,
-  "legacyChartID": "a2146b790ecb40498e988b7948c221235ea83b4c",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S19dd4acb6dc336ea454",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33119,
-    "kaidenAverage": null,
-    "notecount": 501,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19be97eb577fba94967",
-  "isPrimary": true,
-  "legacyChartID": "a0fd4059707a39d55758b4b224cfd7169941a4b0",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S19251aaf95d83b22774",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33119,
-    "kaidenAverage": null,
-    "notecount": 777,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C191b5689fea5f551fe3",
-  "isPrimary": true,
-  "legacyChartID": "918ee8f4412d21a0f6a04c5613babbb895f4aba7",
-  "level": "7",
-  "levelNum": 7,
-  "songID": "S19251aaf95d83b22774",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33119,
-    "kaidenAverage": null,
-    "notecount": 1140,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19a46b353d2838f26fc",
-  "isPrimary": true,
-  "legacyChartID": "1b9624efad15aac54ce4f8baa98b443f710155da",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19251aaf95d83b22774",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33120,
-    "kaidenAverage": null,
-    "notecount": 605,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19fe5e017d2b3914be7",
-  "isPrimary": true,
-  "legacyChartID": "a9eb7d38179a5dd560f191608dca0c57d118c730",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S19bd502dae9343e2f7f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33120,
-    "kaidenAverage": null,
-    "notecount": 961,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19e0355cbc80fa3ac18",
-  "isPrimary": true,
-  "legacyChartID": "05707149c85dbe245a86d97384cc2cbbf6b6cc29",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S19bd502dae9343e2f7f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33120,
-    "kaidenAverage": null,
-    "notecount": 1511,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C195a851b57d12ef0f6d",
-  "isPrimary": true,
-  "legacyChartID": "89e53e0234bd717722df387aaba0393c12ff4b67",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S19bd502dae9343e2f7f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33121,
-    "kaidenAverage": null,
-    "notecount": 647,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C191af565dc10f3d0944",
-  "isPrimary": true,
-  "legacyChartID": "7be4790ae787fc7996eb562682406e0b4dc8f05b",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S1990f414129cbbe810d",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33121,
-    "kaidenAverage": null,
-    "notecount": 1038,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C1983bebbca0af10fb9b",
-  "isPrimary": true,
-  "legacyChartID": "71f0adc7c27ef09467882711b8f6863ef65a64dd",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S1990f414129cbbe810d",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33121,
-    "kaidenAverage": null,
-    "notecount": 1547,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19cedfaa3695e09810f",
-  "isPrimary": true,
-  "legacyChartID": "1586d82bd5458146768161676d84d42484a6c6ba",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S1990f414129cbbe810d",
-  "versions": [
-    "33",
-    "inf"
-  ]
-}
+	}
 ]

--- a/db/seeds/charts-iidx-sp.json
+++ b/db/seeds/charts-iidx-sp.json
@@ -74,6 +74,470 @@
 			"bpiCoefficient": null,
 			"hashSHA256": null,
 			"inGameID": [
+				33094
+			],
+			"kaidenAverage": null,
+			"notecount": 1101,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19cdf35a4ca9c111f77",
+		"isPrimary": true,
+		"legacyChartID": "5cc5a3d3054bb056265a498eeabf98b72af50f56",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S191de0bc75be28bf112",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33094,
+			"kaidenAverage": null,
+			"notecount": 701,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19de662dbc194909052",
+		"isPrimary": true,
+		"legacyChartID": "406f939de3feff06c8ae7b24a01a20ce9968295a",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S191de0bc75be28bf112",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33094,
+			"kaidenAverage": null,
+			"notecount": 396,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19693b539d39835dfbd",
+		"isPrimary": true,
+		"legacyChartID": "3247a9897e0af16ab2bc06f624aa897a21c6d467",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S191de0bc75be28bf112",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33117,
+			"kaidenAverage": null,
+			"notecount": 1790,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C191a35ccdf8d3c8578f",
+		"isPrimary": true,
+		"legacyChartID": "fdad2a3538cd979107442c2fa935981f9611c012",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S1920f6348d8557a1085",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33117,
+			"kaidenAverage": null,
+			"notecount": 1085,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19795cf8e160b234ff3",
+		"isPrimary": true,
+		"legacyChartID": "8705223c74956369d6eab1042b434adb635ead24",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S1920f6348d8557a1085",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33117,
+			"kaidenAverage": null,
+			"notecount": 652,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19e994eb66052da10bb",
+		"isPrimary": true,
+		"legacyChartID": "51dd687d58177edead4405a2c60422c51ff93b8f",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S1920f6348d8557a1085",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33119,
+			"kaidenAverage": null,
+			"notecount": 1149,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19214f7112cd054fc21",
+		"isPrimary": true,
+		"legacyChartID": "6a126495272af9db4fee92c4c5340736894ecf3b",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19251aaf95d83b22774",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33119,
+			"kaidenAverage": null,
+			"notecount": 715,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C193645c48cfd05fdb90",
+		"isPrimary": true,
+		"legacyChartID": "ea51683698cb05745478b0329864b5c3ae4fdbff",
+		"level": "7",
+		"levelNum": 7,
+		"songID": "S19251aaf95d83b22774",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33119,
+			"kaidenAverage": null,
+			"notecount": 502,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C1996fb649c59ef01b77",
+		"isPrimary": true,
+		"legacyChartID": "d9c6d97db1d5c4131b913e63492a2433d150de73",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19251aaf95d83b22774",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33087,
+			"kaidenAverage": null,
+			"notecount": 1618,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C191fea3ddca04762ba8",
+		"isPrimary": true,
+		"legacyChartID": "3031c1b3b70bdb84451b2a376fe7a5829b0d8604",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S193608b356794611ada",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33087,
+			"kaidenAverage": null,
+			"notecount": 933,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19f000ca843b0607cda",
+		"isPrimary": true,
+		"legacyChartID": "cea20a5a7c966fe42147bf8292953c27173bbe89",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S193608b356794611ada",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33087,
+			"kaidenAverage": null,
+			"notecount": 447,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19080156e6881b2c986",
+		"isPrimary": true,
+		"legacyChartID": "fc14c67d0bdfaa01fae64c207ae0a7302ade4038",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S193608b356794611ada",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33116,
+			"kaidenAverage": null,
+			"notecount": 1145,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19a743c1c64be642137",
+		"isPrimary": true,
+		"legacyChartID": "67a8bf8ad5a26be5ca9849828e6f0fde7eff198d",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19418561db2805a0592",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33116,
+			"kaidenAverage": null,
+			"notecount": 829,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19e24054e7d5d64880a",
+		"isPrimary": true,
+		"legacyChartID": "d0fdd542ce64429d3df7dd2352ea33a2547e5fcf",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19418561db2805a0592",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33116,
+			"kaidenAverage": null,
+			"notecount": 404,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19c26e748b7883dc77c",
+		"isPrimary": true,
+		"legacyChartID": "20b52c4326c4c73de64da89855589e00e16e182e",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19418561db2805a0592",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33092,
+			"kaidenAverage": null,
+			"notecount": 1493,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C190d9501ea403ecf4e8",
+		"isPrimary": true,
+		"legacyChartID": "a5ca0ce3f79223c1a1880e950e6aa12d95933b13",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S195b41082f57a270a83",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33092,
+			"kaidenAverage": null,
+			"notecount": 1054,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19c53f63a42101a4e62",
+		"isPrimary": true,
+		"legacyChartID": "974155e7a0c563861ec9c57a0755bb63e73f6763",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S195b41082f57a270a83",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33092,
+			"kaidenAverage": null,
+			"notecount": 486,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19d6194edf5c8048f1f",
+		"isPrimary": true,
+		"legacyChartID": "d118353706c079e83aa612601d20ea99d74fc66f",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S195b41082f57a270a83",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33089,
+			"kaidenAverage": null,
+			"notecount": 1759,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C1943e630d4cc5825153",
+		"isPrimary": true,
+		"legacyChartID": "c32cc75f22c7001e75cc009fb02c8d64937c8003",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S1966940525062bf23cb",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33089,
+			"kaidenAverage": null,
+			"notecount": 1168,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C199393fb43c2a06985f",
+		"isPrimary": true,
+		"legacyChartID": "648b4214663a48b6071676472fb182549e0ce34f",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S1966940525062bf23cb",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33089,
+			"kaidenAverage": null,
+			"notecount": 526,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C1976c1eb9c0ed4d4c99",
+		"isPrimary": true,
+		"legacyChartID": "50d73207772c541c68e016236e329ef12ac782b9",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S1966940525062bf23cb",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": [
 				80111
 			],
 			"kaidenAverage": null,
@@ -280,6 +744,270 @@
 			"2dxtraSet": null,
 			"bpiCoefficient": null,
 			"hashSHA256": null,
+			"inGameID": 33093,
+			"kaidenAverage": null,
+			"notecount": 1590,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C197dcd57681768cfede",
+		"isPrimary": true,
+		"legacyChartID": "972707aa211c99de8c5d21e602693352aa274660",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S198323427fea95b582f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33093,
+			"kaidenAverage": null,
+			"notecount": 1044,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C196c4976efa81d7f7cb",
+		"isPrimary": true,
+		"legacyChartID": "874850f62edcb7620dcee3fc6be007fb7d714dd5",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S198323427fea95b582f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33093,
+			"kaidenAverage": null,
+			"notecount": 562,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C1920d622a27a0540e45",
+		"isPrimary": true,
+		"legacyChartID": "e3cf62900b0e58ff130423a97836a4c1f4b3a656",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S198323427fea95b582f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33088,
+			"kaidenAverage": null,
+			"notecount": 1289,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19099c80c8fe968adf1",
+		"isPrimary": true,
+		"legacyChartID": "9e477030a793921775ca86e6531fcf89566bfbb3",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19858e92318551cd3f9",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33088,
+			"kaidenAverage": null,
+			"notecount": 846,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C198e1744ea51e325a0c",
+		"isPrimary": true,
+		"legacyChartID": "91388012266a39f6707e181587f088bee1def610",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19858e92318551cd3f9",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33088,
+			"kaidenAverage": null,
+			"notecount": 390,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19f9d1f0eb9f4d1b97c",
+		"isPrimary": true,
+		"legacyChartID": "570ce9774e41388c0f2fa1084853a231a83405e2",
+		"level": "4",
+		"levelNum": 4,
+		"songID": "S19858e92318551cd3f9",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33121,
+			"kaidenAverage": null,
+			"notecount": 1618,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19a1de311109189310e",
+		"isPrimary": true,
+		"legacyChartID": "cf16eddf36769309122c31ff8548b9611e539431",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S1990f414129cbbe810d",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33121,
+			"kaidenAverage": null,
+			"notecount": 991,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C1905868af5ca4af575b",
+		"isPrimary": true,
+		"legacyChartID": "244e35d295c7e28adaf1759b6d45dac0208e91c7",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S1990f414129cbbe810d",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33121,
+			"kaidenAverage": null,
+			"notecount": 641,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C197b9feac853af7b0ee",
+		"isPrimary": true,
+		"legacyChartID": "47963f57acdfcef028bea8409d7b1cddc89f0301",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S1990f414129cbbe810d",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33090,
+			"kaidenAverage": null,
+			"notecount": 1203,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19d49b582a5467abda8",
+		"isPrimary": true,
+		"legacyChartID": "fa85b226867b72820b86986bc88b8b37ed1daa4d",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19942cd2d4bb159f3cd",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33090,
+			"kaidenAverage": null,
+			"notecount": 812,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C198ca91d21dda5bc02a",
+		"isPrimary": true,
+		"legacyChartID": "c3809c0f7ff301b58bd3425b1d3812814046bb68",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19942cd2d4bb159f3cd",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33090,
+			"kaidenAverage": null,
+			"notecount": 467,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C196619f090535afffd9",
+		"isPrimary": true,
+		"legacyChartID": "1bd686fd16102eb33f78a3e21ba1e0a7e9ce309a",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19942cd2d4bb159f3cd",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
 			"inGameID": [
 				80109
 			],
@@ -341,6 +1069,204 @@
 		"levelNum": 5,
 		"songID": "S19a282b7e4c2933820b",
 		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33115,
+			"kaidenAverage": null,
+			"notecount": 1249,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C1978146ee4ead47f2e3",
+		"isPrimary": true,
+		"legacyChartID": "60e689e91362daf6f5230faf3a34ad1cad49fc67",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19a9fc151bbcaf0cd7c",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33115,
+			"kaidenAverage": null,
+			"notecount": 949,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C1905e0ed8decd8028be",
+		"isPrimary": true,
+		"legacyChartID": "e941781200e2d1368696f70fbe1266f6969cde7d",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19a9fc151bbcaf0cd7c",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33115,
+			"kaidenAverage": null,
+			"notecount": 545,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19763567d9720b8ab13",
+		"isPrimary": true,
+		"legacyChartID": "8ff4ac3915b1b465e8ee5c886742d07bd691488f",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19a9fc151bbcaf0cd7c",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33120,
+			"kaidenAverage": null,
+			"notecount": 1476,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C195aa2b28fa86cb8d0f",
+		"isPrimary": true,
+		"legacyChartID": "ae89a364c1db45bdae6402e611668c58d513bfe0",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19bd502dae9343e2f7f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33120,
+			"kaidenAverage": null,
+			"notecount": 908,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C1927a3aa71f2a09ac85",
+		"isPrimary": true,
+		"legacyChartID": "f050098c5fd993a946a77e30748c49825c1aa134",
+		"level": "8",
+		"levelNum": 8,
+		"songID": "S19bd502dae9343e2f7f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33120,
+			"kaidenAverage": null,
+			"notecount": 655,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C19faade8a279227e590",
+		"isPrimary": true,
+		"legacyChartID": "ff8aeaf16fea78d1a1fe20bf1f75fd22f62640d5",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19bd502dae9343e2f7f",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33091,
+			"kaidenAverage": null,
+			"notecount": 1730,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C198f69d5c7db25ab063",
+		"isPrimary": true,
+		"legacyChartID": "7f5dba71bd32be48a747019630b4acefc65e50d2",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19beaf6181b5eb809e6",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33091,
+			"kaidenAverage": null,
+			"notecount": 1159,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C19e39e282fdea09470b",
+		"isPrimary": true,
+		"legacyChartID": "57d5eb20d8ab62e45184af59ddadbdd9098f95d1",
+		"level": "10",
+		"levelNum": 10,
+		"songID": "S19beaf6181b5eb809e6",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33091,
+			"kaidenAverage": null,
+			"notecount": 599,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C190bf521ca1c6f7c72e",
+		"isPrimary": true,
+		"legacyChartID": "93123cf1d0d961791d82c3f3dcc3772a7502f461",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19beaf6181b5eb809e6",
+		"versions": [
+			"33",
 			"inf"
 		]
 	},
@@ -162536,6 +163462,27 @@
 			"hashSHA256": null,
 			"inGameID": 22007,
 			"kaidenAverage": null,
+			"notecount": 1660,
+			"worldRecord": null
+		},
+		"difficulty": "LEGGENDARIA",
+		"id": "C1958f311bfbd5a73825",
+		"isPrimary": true,
+		"legacyChartID": "c1f3290b46881442c446c7dd781cf23902b7b9a3",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19d35e0b3e0c8277500",
+		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 22007,
+			"kaidenAverage": null,
 			"notecount": 402,
 			"worldRecord": null
 		},
@@ -162572,27 +163519,6 @@
 			"33",
 			"32-omni"
 		]
-	},
-	{
-  		"data": {
-    		"2dxtraSet": null,
-    		"bpiCoefficient": null,
-    		"hashSHA256": null,
-    		"inGameID": 22007,
-    		"kaidenAverage": null,
-    		"notecount": 1660,
-    		"worldRecord": null
-  		},
-  	"difficulty": "LEGGENDARIA",
-  	"id": "C1958f311bfbd5a73825",
-  	"isPrimary": true,
-  	"legacyChartID": "c1f3290b46881442c446c7dd781cf23902b7b9a3",
-  	"level": "12",
-  	"levelNum": 12,
-  	"songID": "S19d35e0b3e0c8277500",
-  	"versions": [
-    	"inf"
-  	]
 	},
 	{
 		"data": {
@@ -223204,6 +224130,27 @@
 			"hashSHA256": null,
 			"inGameID": 25070,
 			"kaidenAverage": null,
+			"notecount": 1460,
+			"worldRecord": null
+		},
+		"difficulty": "LEGGENDARIA",
+		"id": "C19a7efcfd8bc583b3f4",
+		"isPrimary": true,
+		"legacyChartID": "671262a114d3d8c955bda2011c04c7bd80aa200e",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19d35e0b5d049d6aa1b",
+		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 25070,
+			"kaidenAverage": null,
 			"notecount": 459,
 			"worldRecord": null
 		},
@@ -223238,27 +224185,6 @@
 			"32-omni"
 		]
 	},
-	{
-  		"data": {
-    		"2dxtraSet": null,
-    		"bpiCoefficient": null,
-    		"hashSHA256": null,
-    		"inGameID": 25070,
-    		"kaidenAverage": null,
-    		"notecount": 1460,
-    		"worldRecord": null
-  },
-  "difficulty": "LEGGENDARIA",
-  "id": "C19a7efcfd8bc583b3f4",
-  "isPrimary": true,
-  "legacyChartID": "671262a114d3d8c955bda2011c04c7bd80aa200e",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S19d35e0b5d049d6aa1b",
-  "versions": [
-    "inf"
-  ]
-},
 	{
 		"data": {
 			"2dxtraSet": null,
@@ -240080,6 +241006,27 @@
 			"hashSHA256": null,
 			"inGameID": 27100,
 			"kaidenAverage": null,
+			"notecount": 1254,
+			"worldRecord": null
+		},
+		"difficulty": "LEGGENDARIA",
+		"id": "C198d49750f17fc5926c",
+		"isPrimary": true,
+		"legacyChartID": "6fa47f56030df828534a7aa5584d584189b9e78c",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19d35e0b659807e9b23",
+		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 27100,
+			"kaidenAverage": null,
 			"notecount": 398,
 			"worldRecord": null
 		},
@@ -240110,27 +241057,6 @@
 			"33",
 			"32-omni"
 		]
-	},
-	{
-  		"data": {
-    		"2dxtraSet": null,
-    		"bpiCoefficient": null,
-    		"hashSHA256": null,
-    		"inGameID": 27100,
-    		"kaidenAverage": null,
-    		"notecount": 1254,
-    		"worldRecord": null
-  		},
-  	"difficulty": "LEGGENDARIA",
-  	"id": "C198d49750f17fc5926c",
-  	"isPrimary": true,
-  	"legacyChartID": "6fa47f56030df828534a7aa5584d584189b9e78c",
-  	"level": "12",
-  	"levelNum": 12,
-  	"songID": "S19d35e0b659807e9b23",
-  	"versions": [
-    	"inf"
-  		]
 	},
 	{
 		"data": {
@@ -269535,6 +270461,30 @@
 				30228
 			],
 			"kaidenAverage": null,
+			"notecount": 1566,
+			"worldRecord": null
+		},
+		"difficulty": "LEGGENDARIA",
+		"id": "C195a013b5c0ac36126e",
+		"isPrimary": true,
+		"legacyChartID": "28c6cb23fd7d1f805b87f3e239c68f4f4679fe99",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19d35e0b773a019cfe0",
+		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": [
+				80028,
+				30228
+			],
+			"kaidenAverage": null,
 			"notecount": 459,
 			"worldRecord": null
 		},
@@ -269552,30 +270502,6 @@
 			"32-omni"
 		]
 	},
-	{
-  	"data": {
-    	"2dxtraSet": null,
-    	"bpiCoefficient": null,
-    	"hashSHA256": null,
-    	"inGameID": [
-      		80028,
-      		30228
-    	],
-    	"kaidenAverage": null,
-    	"notecount": 1566,
-    	"worldRecord": null
-  	},
-  	"difficulty": "LEGGENDARIA",
-  	"id": "C195a013b5c0ac36126e",
-  	"isPrimary": true,
-  	"legacyChartID": "28c6cb23fd7d1f805b87f3e239c68f4f4679fe99",
-  	"level": "11",
-  	"levelNum": 11,
-  	"songID": "S19d35e0b773a019cfe0",
-  	"versions": [
-	    "inf"
-  ]
-},
 	{
 		"data": {
 			"2dxtraSet": null,
@@ -299923,6 +300849,72 @@
 		"levelNum": 4,
 		"songID": "S19d35e0b8f12116f6da",
 		"versions": [
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33118,
+			"kaidenAverage": null,
+			"notecount": 1504,
+			"worldRecord": null
+		},
+		"difficulty": "ANOTHER",
+		"id": "C19b6022d2541b5049ab",
+		"isPrimary": true,
+		"legacyChartID": "1b3e7421b394fe2af65236390fa3b670c8fa9bd5",
+		"level": "11",
+		"levelNum": 11,
+		"songID": "S19dd4acb6dc336ea454",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33118,
+			"kaidenAverage": null,
+			"notecount": 876,
+			"worldRecord": null
+		},
+		"difficulty": "HYPER",
+		"id": "C1986e2414f17d9bc2fb",
+		"isPrimary": true,
+		"legacyChartID": "33744da13f91efcc1db49a06b6e3d64968cb84be",
+		"level": "9",
+		"levelNum": 9,
+		"songID": "S19dd4acb6dc336ea454",
+		"versions": [
+			"33",
+			"inf"
+		]
+	},
+	{
+		"data": {
+			"2dxtraSet": null,
+			"bpiCoefficient": null,
+			"hashSHA256": null,
+			"inGameID": 33118,
+			"kaidenAverage": null,
+			"notecount": 601,
+			"worldRecord": null
+		},
+		"difficulty": "NORMAL",
+		"id": "C198a4971d4722ca309b",
+		"isPrimary": true,
+		"legacyChartID": "02b4932a709661f5e3a9e524098d0892e4ee0470",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19dd4acb6dc336ea454",
+		"versions": [
+			"33",
 			"inf"
 		]
 	},
@@ -814342,997 +815334,5 @@
 		"versions": [
 			"31-2dxtra"
 		]
-	},
-	{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33087,
-    "kaidenAverage": null,
-    "notecount": 447,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19080156e6881b2c986",
-  "isPrimary": true,
-  "legacyChartID": "fc14c67d0bdfaa01fae64c207ae0a7302ade4038",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S193608b356794611ada",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33087,
-    "kaidenAverage": null,
-    "notecount": 933,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19f000ca843b0607cda",
-  "isPrimary": true,
-  "legacyChartID": "cea20a5a7c966fe42147bf8292953c27173bbe89",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S193608b356794611ada",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33087,
-    "kaidenAverage": null,
-    "notecount": 1618,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C191fea3ddca04762ba8",
-  "isPrimary": true,
-  "legacyChartID": "3031c1b3b70bdb84451b2a376fe7a5829b0d8604",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S193608b356794611ada",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33088,
-    "kaidenAverage": null,
-    "notecount": 390,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19f9d1f0eb9f4d1b97c",
-  "isPrimary": true,
-  "legacyChartID": "570ce9774e41388c0f2fa1084853a231a83405e2",
-  "level": "4",
-  "levelNum": 4,
-  "songID": "S19858e92318551cd3f9",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33088,
-    "kaidenAverage": null,
-    "notecount": 846,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C198e1744ea51e325a0c",
-  "isPrimary": true,
-  "legacyChartID": "91388012266a39f6707e181587f088bee1def610",
-  "level": "8",
-  "levelNum": 8,
-  "songID": "S19858e92318551cd3f9",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33088,
-    "kaidenAverage": null,
-    "notecount": 1289,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19099c80c8fe968adf1",
-  "isPrimary": true,
-  "legacyChartID": "9e477030a793921775ca86e6531fcf89566bfbb3",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19858e92318551cd3f9",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33089,
-    "kaidenAverage": null,
-    "notecount": 526,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C1976c1eb9c0ed4d4c99",
-  "isPrimary": true,
-  "legacyChartID": "50d73207772c541c68e016236e329ef12ac782b9",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S1966940525062bf23cb",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33089,
-    "kaidenAverage": null,
-    "notecount": 1168,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C199393fb43c2a06985f",
-  "isPrimary": true,
-  "legacyChartID": "648b4214663a48b6071676472fb182549e0ce34f",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S1966940525062bf23cb",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33089,
-    "kaidenAverage": null,
-    "notecount": 1759,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C1943e630d4cc5825153",
-  "isPrimary": true,
-  "legacyChartID": "c32cc75f22c7001e75cc009fb02c8d64937c8003",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S1966940525062bf23cb",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33090,
-    "kaidenAverage": null,
-    "notecount": 467,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C196619f090535afffd9",
-  "isPrimary": true,
-  "legacyChartID": "1bd686fd16102eb33f78a3e21ba1e0a7e9ce309a",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S19942cd2d4bb159f3cd",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33090,
-    "kaidenAverage": null,
-    "notecount": 812,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C198ca91d21dda5bc02a",
-  "isPrimary": true,
-  "legacyChartID": "c3809c0f7ff301b58bd3425b1d3812814046bb68",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S19942cd2d4bb159f3cd",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33090,
-    "kaidenAverage": null,
-    "notecount": 1203,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19d49b582a5467abda8",
-  "isPrimary": true,
-  "legacyChartID": "fa85b226867b72820b86986bc88b8b37ed1daa4d",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19942cd2d4bb159f3cd",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33091,
-    "kaidenAverage": null,
-    "notecount": 599,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C190bf521ca1c6f7c72e",
-  "isPrimary": true,
-  "legacyChartID": "93123cf1d0d961791d82c3f3dcc3772a7502f461",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S19beaf6181b5eb809e6",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33091,
-    "kaidenAverage": null,
-    "notecount": 1159,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19e39e282fdea09470b",
-  "isPrimary": true,
-  "legacyChartID": "57d5eb20d8ab62e45184af59ddadbdd9098f95d1",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19beaf6181b5eb809e6",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33091,
-    "kaidenAverage": null,
-    "notecount": 1730,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C198f69d5c7db25ab063",
-  "isPrimary": true,
-  "legacyChartID": "7f5dba71bd32be48a747019630b4acefc65e50d2",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S19beaf6181b5eb809e6",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33092,
-    "kaidenAverage": null,
-    "notecount": 486,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19d6194edf5c8048f1f",
-  "isPrimary": true,
-  "legacyChartID": "d118353706c079e83aa612601d20ea99d74fc66f",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S195b41082f57a270a83",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33092,
-    "kaidenAverage": null,
-    "notecount": 1054,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19c53f63a42101a4e62",
-  "isPrimary": true,
-  "legacyChartID": "974155e7a0c563861ec9c57a0755bb63e73f6763",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S195b41082f57a270a83",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33092,
-    "kaidenAverage": null,
-    "notecount": 1493,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C190d9501ea403ecf4e8",
-  "isPrimary": true,
-  "legacyChartID": "a5ca0ce3f79223c1a1880e950e6aa12d95933b13",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S195b41082f57a270a83",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33093,
-    "kaidenAverage": null,
-    "notecount": 562,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C1920d622a27a0540e45",
-  "isPrimary": true,
-  "legacyChartID": "e3cf62900b0e58ff130423a97836a4c1f4b3a656",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S198323427fea95b582f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33093,
-    "kaidenAverage": null,
-    "notecount": 1044,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C196c4976efa81d7f7cb",
-  "isPrimary": true,
-  "legacyChartID": "874850f62edcb7620dcee3fc6be007fb7d714dd5",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S198323427fea95b582f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33093,
-    "kaidenAverage": null,
-    "notecount": 1590,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C197dcd57681768cfede",
-  "isPrimary": true,
-  "legacyChartID": "972707aa211c99de8c5d21e602693352aa274660",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S198323427fea95b582f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33094,
-    "kaidenAverage": null,
-    "notecount": 396,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19693b539d39835dfbd",
-  "isPrimary": true,
-  "legacyChartID": "3247a9897e0af16ab2bc06f624aa897a21c6d467",
-  "level": "4",
-  "levelNum": 4,
-  "songID": "S191de0bc75be28bf112",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33094,
-    "kaidenAverage": null,
-    "notecount": 701,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19de662dbc194909052",
-  "isPrimary": true,
-  "legacyChartID": "406f939de3feff06c8ae7b24a01a20ce9968295a",
-  "level": "7",
-  "levelNum": 7,
-  "songID": "S191de0bc75be28bf112",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": [
-      33094
-    ],
-    "kaidenAverage": null,
-    "notecount": 1101,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19cdf35a4ca9c111f77",
-  "isPrimary": true,
-  "legacyChartID": "5cc5a3d3054bb056265a498eeabf98b72af50f56",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S191de0bc75be28bf112",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33115,
-    "kaidenAverage": null,
-    "notecount": 545,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19763567d9720b8ab13",
-  "isPrimary": true,
-  "legacyChartID": "8ff4ac3915b1b465e8ee5c886742d07bd691488f",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S19a9fc151bbcaf0cd7c",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33115,
-    "kaidenAverage": null,
-    "notecount": 949,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C1905e0ed8decd8028be",
-  "isPrimary": true,
-  "legacyChartID": "e941781200e2d1368696f70fbe1266f6969cde7d",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S19a9fc151bbcaf0cd7c",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33115,
-    "kaidenAverage": null,
-    "notecount": 1249,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C1978146ee4ead47f2e3",
-  "isPrimary": true,
-  "legacyChartID": "60e689e91362daf6f5230faf3a34ad1cad49fc67",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S19a9fc151bbcaf0cd7c",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33116,
-    "kaidenAverage": null,
-    "notecount": 404,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19c26e748b7883dc77c",
-  "isPrimary": true,
-  "legacyChartID": "20b52c4326c4c73de64da89855589e00e16e182e",
-  "level": "4",
-  "levelNum": 4,
-  "songID": "S19418561db2805a0592",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33116,
-    "kaidenAverage": null,
-    "notecount": 829,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19e24054e7d5d64880a",
-  "isPrimary": true,
-  "legacyChartID": "d0fdd542ce64429d3df7dd2352ea33a2547e5fcf",
-  "level": "8",
-  "levelNum": 8,
-  "songID": "S19418561db2805a0592",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33116,
-    "kaidenAverage": null,
-    "notecount": 1145,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19a743c1c64be642137",
-  "isPrimary": true,
-  "legacyChartID": "67a8bf8ad5a26be5ca9849828e6f0fde7eff198d",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19418561db2805a0592",
-  "versions": [
-    "33",
-	"inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33117,
-    "kaidenAverage": null,
-    "notecount": 652,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19e994eb66052da10bb",
-  "isPrimary": true,
-  "legacyChartID": "51dd687d58177edead4405a2c60422c51ff93b8f",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S1920f6348d8557a1085",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33117,
-    "kaidenAverage": null,
-    "notecount": 1085,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C19795cf8e160b234ff3",
-  "isPrimary": true,
-  "legacyChartID": "8705223c74956369d6eab1042b434adb635ead24",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S1920f6348d8557a1085",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33117,
-    "kaidenAverage": null,
-    "notecount": 1790,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C191a35ccdf8d3c8578f",
-  "isPrimary": true,
-  "legacyChartID": "fdad2a3538cd979107442c2fa935981f9611c012",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S1920f6348d8557a1085",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33118,
-    "kaidenAverage": null,
-    "notecount": 601,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C198a4971d4722ca309b",
-  "isPrimary": true,
-  "legacyChartID": "02b4932a709661f5e3a9e524098d0892e4ee0470",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S19dd4acb6dc336ea454",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33118,
-    "kaidenAverage": null,
-    "notecount": 876,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C1986e2414f17d9bc2fb",
-  "isPrimary": true,
-  "legacyChartID": "33744da13f91efcc1db49a06b6e3d64968cb84be",
-  "level": "9",
-  "levelNum": 9,
-  "songID": "S19dd4acb6dc336ea454",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33118,
-    "kaidenAverage": null,
-    "notecount": 1504,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19b6022d2541b5049ab",
-  "isPrimary": true,
-  "legacyChartID": "1b3e7421b394fe2af65236390fa3b670c8fa9bd5",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S19dd4acb6dc336ea454",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33119,
-    "kaidenAverage": null,
-    "notecount": 502,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C1996fb649c59ef01b77",
-  "isPrimary": true,
-  "legacyChartID": "d9c6d97db1d5c4131b913e63492a2433d150de73",
-  "level": "5",
-  "levelNum": 5,
-  "songID": "S19251aaf95d83b22774",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33119,
-    "kaidenAverage": null,
-    "notecount": 715,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C193645c48cfd05fdb90",
-  "isPrimary": true,
-  "legacyChartID": "ea51683698cb05745478b0329864b5c3ae4fdbff",
-  "level": "7",
-  "levelNum": 7,
-  "songID": "S19251aaf95d83b22774",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33119,
-    "kaidenAverage": null,
-    "notecount": 1149,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19214f7112cd054fc21",
-  "isPrimary": true,
-  "legacyChartID": "6a126495272af9db4fee92c4c5340736894ecf3b",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S19251aaf95d83b22774",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33120,
-    "kaidenAverage": null,
-    "notecount": 655,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C19faade8a279227e590",
-  "isPrimary": true,
-  "legacyChartID": "ff8aeaf16fea78d1a1fe20bf1f75fd22f62640d5",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S19bd502dae9343e2f7f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33120,
-    "kaidenAverage": null,
-    "notecount": 908,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C1927a3aa71f2a09ac85",
-  "isPrimary": true,
-  "legacyChartID": "f050098c5fd993a946a77e30748c49825c1aa134",
-  "level": "8",
-  "levelNum": 8,
-  "songID": "S19bd502dae9343e2f7f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33120,
-    "kaidenAverage": null,
-    "notecount": 1476,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C195aa2b28fa86cb8d0f",
-  "isPrimary": true,
-  "legacyChartID": "ae89a364c1db45bdae6402e611668c58d513bfe0",
-  "level": "11",
-  "levelNum": 11,
-  "songID": "S19bd502dae9343e2f7f",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33121,
-    "kaidenAverage": null,
-    "notecount": 641,
-    "worldRecord": null
-  },
-  "difficulty": "NORMAL",
-  "id": "C197b9feac853af7b0ee",
-  "isPrimary": true,
-  "legacyChartID": "47963f57acdfcef028bea8409d7b1cddc89f0301",
-  "level": "6",
-  "levelNum": 6,
-  "songID": "S1990f414129cbbe810d",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33121,
-    "kaidenAverage": null,
-    "notecount": 991,
-    "worldRecord": null
-  },
-  "difficulty": "HYPER",
-  "id": "C1905868af5ca4af575b",
-  "isPrimary": true,
-  "legacyChartID": "244e35d295c7e28adaf1759b6d45dac0208e91c7",
-  "level": "10",
-  "levelNum": 10,
-  "songID": "S1990f414129cbbe810d",
-  "versions": [
-    "33",
-    "inf"
-  ]
-},
-{
-  "data": {
-    "2dxtraSet": null,
-    "bpiCoefficient": null,
-    "hashSHA256": null,
-    "inGameID": 33121,
-    "kaidenAverage": null,
-    "notecount": 1618,
-    "worldRecord": null
-  },
-  "difficulty": "ANOTHER",
-  "id": "C19a1de311109189310e",
-  "isPrimary": true,
-  "legacyChartID": "cf16eddf36769309122c31ff8548b9611e539431",
-  "level": "12",
-  "levelNum": 12,
-  "songID": "S1990f414129cbbe810d",
-  "versions": [
-    "33",
-    "inf"
-  ]
-}
+	}
 ]

--- a/db/seeds/songs-iidx.json
+++ b/db/seeds/songs-iidx.json
@@ -17,6 +17,98 @@
 	},
 	{
 		"altTitles": [],
+		"artist": "Rainy。",
+		"data": {
+			"displayVersion": "33",
+			"genre": "COLOR DANCE POP"
+		},
+		"id": "S191de0bc75be28bf112",
+		"legacySongID": 2605,
+		"searchTerms": [],
+		"title": "COLOR BURST"
+	},
+	{
+		"altTitles": [],
+		"artist": "BlackY feat. Risa Yuzuki",
+		"data": {
+			"displayVersion": "33",
+			"genre": "LIGHTNING Hi-TECH"
+		},
+		"id": "S1920f6348d8557a1085",
+		"legacySongID": 2595,
+		"searchTerms": [],
+		"title": "THUNDERSTRIKE"
+	},
+	{
+		"altTitles": [],
+		"artist": "DÉ DÉ MOUSE",
+		"data": {
+			"displayVersion": "33",
+			"genre": "Nu-NRG / FUTUREDISCO"
+		},
+		"id": "S19251aaf95d83b22774",
+		"legacySongID": 2593,
+		"searchTerms": [],
+		"title": "Get Into The Groove feat.WaMi"
+	},
+	{
+		"altTitles": [],
+		"artist": "Juggernaut",
+		"data": {
+			"displayVersion": "33",
+			"genre": "GLHF"
+		},
+		"id": "S193608b356794611ada",
+		"legacySongID": 2599,
+		"searchTerms": [
+			"GO"
+		],
+		"title": "GO!"
+	},
+	{
+		"altTitles": [],
+		"artist": "暁Records",
+		"data": {
+			"displayVersion": "33",
+			"genre": "JAPANESE ALTERNATIVE ROCK"
+		},
+		"id": "S19418561db2805a0592",
+		"legacySongID": 2596,
+		"searchTerms": [],
+		"title": "Wizards!"
+	},
+	{
+		"altTitles": [],
+		"artist": "Tatsunoshin",
+		"data": {
+			"displayVersion": "33",
+			"genre": "STAR☆CORE"
+		},
+		"id": "S195b41082f57a270a83",
+		"legacySongID": 2602,
+		"searchTerms": [
+			"Meteor Shower"
+		],
+		"title": "Meteor☆Shower"
+	},
+	{
+		"altTitles": [],
+		"artist": "BlackY",
+		"data": {
+			"displayVersion": "33",
+			"genre": "GOLDEN FORCE"
+		},
+		"id": "S1966940525062bf23cb",
+		"legacySongID": 2603,
+		"searchTerms": [
+			"Rizing Gamers",
+			"Rizing-Gamers",
+			"Rising Gamers"
+		],
+		"title": "RIZING-GAMERS."
+	},
+	{
+		"altTitles": [],
 		"artist": "Ryu☆ feat.青龍",
 		"data": {
 			"displayVersion": "inf",
@@ -55,6 +147,54 @@
 	},
 	{
 		"altTitles": [],
+		"artist": "Numb'n'dub",
+		"data": {
+			"displayVersion": "33",
+			"genre": "ブレイクコア"
+		},
+		"id": "S198323427fea95b582f",
+		"legacySongID": 2601,
+		"searchTerms": [],
+		"title": "King of Tribe"
+	},
+	{
+		"altTitles": [],
+		"artist": "SOUND HOLIC feat. Nana Takahashi",
+		"data": {
+			"displayVersion": "33",
+			"genre": "FUTURE VIBES"
+		},
+		"id": "S19858e92318551cd3f9",
+		"legacySongID": 2600,
+		"searchTerms": [],
+		"title": "HORIZON BEATZ"
+	},
+	{
+		"altTitles": [],
+		"artist": "nora2r feat. Liqo & DD\"ナカタ\"Metal",
+		"data": {
+			"displayVersion": "33",
+			"genre": "HYBRID METALCORE"
+		},
+		"id": "S1990f414129cbbe810d",
+		"legacySongID": 2594,
+		"searchTerms": [],
+		"title": "Mighty Beat Monsterz"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ Shimamura",
+		"data": {
+			"displayVersion": "33",
+			"genre": "HARDCORE RAVE"
+		},
+		"id": "S19942cd2d4bb159f3cd",
+		"legacySongID": 2604,
+		"searchTerms": [],
+		"title": "SILKY BRAVE"
+	},
+	{
+		"altTitles": [],
 		"artist": "Another Infinity feat. Mayumi Morinaga",
 		"data": {
 			"displayVersion": "inf",
@@ -64,6 +204,46 @@
 		"legacySongID": 2584,
 		"searchTerms": [],
 		"title": "It's my Miracle"
+	},
+	{
+		"altTitles": [],
+		"artist": "森羅万象",
+		"data": {
+			"displayVersion": "33",
+			"genre": "DANCE POP"
+		},
+		"id": "S19a9fc151bbcaf0cd7c",
+		"legacySongID": 2597,
+		"searchTerms": [
+			"Meteora",
+			"Meteora -meteor-",
+			"meteor"
+		],
+		"title": "メテオラ-meteor-"
+	},
+	{
+		"altTitles": [],
+		"artist": "SOUND HOLIC feat. STEVIE(44MAGNUM)",
+		"data": {
+			"displayVersion": "33",
+			"genre": "CYBER ROCK"
+		},
+		"id": "S19bd502dae9343e2f7f",
+		"legacySongID": 2592,
+		"searchTerms": [],
+		"title": "ESPRIT ONE"
+	},
+	{
+		"altTitles": [],
+		"artist": "MK",
+		"data": {
+			"displayVersion": "33",
+			"genre": "DRUMSTEP"
+		},
+		"id": "S19beaf6181b5eb809e6",
+		"legacySongID": 2598,
+		"searchTerms": [],
+		"title": "Astra Blaze"
 	},
 	{
 		"altTitles": [],
@@ -31522,6 +31702,18 @@
 	},
 	{
 		"altTitles": [],
+		"artist": "OSTER project feat. 花たん",
+		"data": {
+			"displayVersion": "33",
+			"genre": "TRIUMPHAL ANTHEM"
+		},
+		"id": "S19dd4acb6dc336ea454",
+		"legacySongID": 2591,
+		"searchTerms": [],
+		"title": "blue anthem"
+	},
+	{
+		"altTitles": [],
 		"artist": "SOUND HOLIC feat. Nana Takahashi",
 		"data": {
 			"displayVersion": "inf",
@@ -31597,197 +31789,5 @@
 			"Rush"
 		],
 		"title": "Rush!!"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "OSTER project feat. 花たん",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "TRIUMPHAL ANTHEM"
-  		},
-  		"id": "S19dd4acb6dc336ea454",
-  		"legacySongID": 2591,
-  		"searchTerms": [],
-  		"title": "blue anthem"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "SOUND HOLIC feat. STEVIE(44MAGNUM)",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "CYBER ROCK"
-  		},
-  		"id": "S19bd502dae9343e2f7f",
-  		"legacySongID": 2592,
-  		"searchTerms": [],
-  		"title": "ESPRIT ONE"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "DÉ DÉ MOUSE",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "Nu-NRG / FUTUREDISCO"
-  		},
-  		"id": "S19251aaf95d83b22774",
-  		"legacySongID": 2593,
-  		"searchTerms": [],
-  		"title": "Get Into The Groove feat.WaMi"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "nora2r feat. Liqo & DD\"ナカタ\"Metal",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "HYBRID METALCORE"
-  		},
-  		"id": "S1990f414129cbbe810d",
-  		"legacySongID": 2594,
-  		"searchTerms": [],
-  		"title": "Mighty Beat Monsterz"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "BlackY feat. Risa Yuzuki",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "LIGHTNING Hi-TECH"
-  		},
-  		"id": "S1920f6348d8557a1085",
-  		"legacySongID": 2595,
-  		"searchTerms": [],
-  		"title": "THUNDERSTRIKE"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "暁Records",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "JAPANESE ALTERNATIVE ROCK"
-  		},
-  		"id": "S19418561db2805a0592",
-  		"legacySongID": 2596,
-  		"searchTerms": [],
-  		"title": "Wizards!"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "森羅万象",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "DANCE POP"
-  		},
-  		"id": "S19a9fc151bbcaf0cd7c",
-  		"legacySongID": 2597,
-  		"searchTerms": [
-    		"Meteora",
-    		"Meteora -meteor-",
-    		"meteor"
-  		],
-  		"title": "メテオラ-meteor-"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "MK",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "DRUMSTEP"
-  		},
-  		"id": "S19beaf6181b5eb809e6",
-  		"legacySongID": 2598,
-  		"searchTerms": [],
-  		"title": "Astra Blaze"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "Juggernaut",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "GLHF"
-  		},
-  		"id": "S193608b356794611ada",
-  		"legacySongID": 2599,
-  		"searchTerms": [
-    		"GO"
-  		],
-  		"title": "GO!"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "SOUND HOLIC feat. Nana Takahashi",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "FUTURE VIBES"
-  		},
-  		"id": "S19858e92318551cd3f9",
-  		"legacySongID": 2600,
-  		"searchTerms": [],
-  		"title": "HORIZON BEATZ"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "Numb'n'dub",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "ブレイクコア"
-  		},
-  		"id": "S198323427fea95b582f",
-  		"legacySongID": 2601,
-  		"searchTerms": [],
-  		"title": "King of Tribe"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "Tatsunoshin",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "STAR☆CORE"
-  		},
-  		"id": "S195b41082f57a270a83",
-  		"legacySongID": 2602,
-  		"searchTerms": [
-    		"Meteor Shower"
-  		],
-  		"title": "Meteor☆Shower"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "BlackY",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "GOLDEN FORCE"
-  		},
-  		"id": "S1966940525062bf23cb",
-  		"legacySongID": 2603,
-  		"searchTerms": [
-    		"Rizing Gamers",
-    		"Rizing-Gamers",
-    		"Rising Gamers"
-  		],
-  		"title": "RIZING-GAMERS."
-	},
-	{
-  		"altTitles": [],
-  		"artist": "DJ Shimamura",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "HARDCORE RAVE"
-  		},
-  		"id": "S19942cd2d4bb159f3cd",
-  		"legacySongID": 2604,
-  		"searchTerms": [],
-  		"title": "SILKY BRAVE"
-	},
-	{
-  		"altTitles": [],
-  		"artist": "Rainy。",
-  		"data": {
-    		"displayVersion": "33",
-    		"genre": "COLOR DANCE POP"
-  		},
-  		"id": "S191de0bc75be28bf112",
-  		"legacySongID": 2605,
-  		"searchTerms": [],
-  		"title": "COLOR BURST"
 	}
 ]

--- a/typescript/client/src/components/charts/GekichumaiScoreChart.tsx
+++ b/typescript/client/src/components/charts/GekichumaiScoreChart.tsx
@@ -71,6 +71,23 @@ const getScoreYAxisNotch = (game: GameGroup) => (s: number) => {
 	return "";
 };
 
+const getBaseline = (_game: "ongeki", data: Serie[]) => {
+	const dataset = data[0].data;
+	const dv = dataset[dataset.length - 1].y;
+	const finalValue: number = typeof dv === "number" ? dv : 0;
+
+	if (finalValue >= 1007_500) {
+		return 1007_500;
+	}
+	if (finalValue >= 1000_000) {
+		return 1000_000;
+	}
+	if (finalValue >= 990_000) {
+		return 990_000;
+	}
+	return 970_000;
+};
+
 const strokeColor = (
 	type: "BELLS" | Difficulties["chunithm"] | Difficulties["maimaidx"] | Difficulties["ongeki"],
 ) => {
@@ -238,16 +255,17 @@ export default function GekichumaiScoreChart({
 
 	if (type === "Score") {
 		if (game === "ongeki") {
+			const baseline = getBaseline("ongeki", data);
 			component = (
 				<ResponsiveLine
 					{...commonProps}
-					areaBaselineValue={970000}
+					areaBaselineValue={baseline}
 					axisLeft={{
 						tickValues: [970_000, 990_000, 1000_000, 1007_500, 1010_000],
 						format: getScoreYAxisNotch(game),
 					}}
 					colors={strokeColor(difficulty)}
-					data={limitScoreGraph(data, 970_000)}
+					data={limitScoreGraph(data, baseline)}
 					enableGridY={true}
 					gridYValues={[970_000, 980_000, 990_000, 1000_000, 1007_500, 1010_000]}
 					tooltip={(d: PointTooltipProps) => (
@@ -259,7 +277,7 @@ export default function GekichumaiScoreChart({
 						</ChartTooltip>
 					)}
 					yFormat={">-,.0f"}
-					yScale={{ type: "linear", min: 970_000, max: 1010_000 }}
+					yScale={{ type: "linear", min: baseline, max: 1010_000 }}
 				/>
 			);
 		} else if (game === "chunithm") {


### PR DESCRIPTION
Vastly improves clarity for most graphs people are likely to care about.

Before
<img width="731" height="474" alt="Screenshot_20260630_005759" src="https://github.com/user-attachments/assets/622b5b70-ab02-4578-a632-63a8d3468789" />

After
<img width="731" height="474" alt="Screenshot_20260630_005736" src="https://github.com/user-attachments/assets/40301326-5d11-4954-8b1f-9af6c604a607" />
