### PR TITLE
seeds: update SDVX AC seeds to 2026063000

### DIFF
--- a/db/seeds/charts-sdvx.json
+++ b/db/seeds/charts-sdvx.json
@@ -115775,8 +115775,7 @@
 		"songID": "S19d35e0e4b510d9938d",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115792,8 +115791,7 @@
 		"songID": "S19d35e0e4b510d9938d",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115819,8 +115817,7 @@
 		"songID": "S19d35e0e4b510d9938d",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115836,8 +115833,7 @@
 		"songID": "S19d35e0e4b510d9938d",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115853,8 +115849,7 @@
 		"songID": "S19d35e0e4b67e6fb846",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115870,8 +115865,7 @@
 		"songID": "S19d35e0e4b67e6fb846",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115897,8 +115891,7 @@
 		"songID": "S19d35e0e4b67e6fb846",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115914,8 +115907,7 @@
 		"songID": "S19d35e0e4b67e6fb846",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115931,8 +115923,7 @@
 		"songID": "S19d35e0e4b705efdbbd",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115948,8 +115939,7 @@
 		"songID": "S19d35e0e4b705efdbbd",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115980,8 +115970,7 @@
 		"songID": "S19d35e0e4b705efdbbd",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -115997,8 +115986,7 @@
 		"songID": "S19d35e0e4b705efdbbd",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -116315,8 +116303,7 @@
 		"songID": "S19d35e0e4bcad9d34bc",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -116332,8 +116319,7 @@
 		"songID": "S19d35e0e4bcad9d34bc",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -116364,8 +116350,7 @@
 		"songID": "S19d35e0e4bcad9d34bc",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -116381,8 +116366,7 @@
 		"songID": "S19d35e0e4bcad9d34bc",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -116398,8 +116382,7 @@
 		"songID": "S19d35e0e4bd9c19f54e",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -116415,8 +116398,7 @@
 		"songID": "S19d35e0e4bd9c19f54e",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -116442,8 +116424,7 @@
 		"songID": "S19d35e0e4bd9c19f54e",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -116459,8 +116440,7 @@
 		"songID": "S19d35e0e4bd9c19f54e",
 		"versions": [
 			"vivid",
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -162055,8 +162035,7 @@
 		"levelNum": 10,
 		"songID": "S19d35e0e75afbb825d3",
 		"versions": [
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -162071,8 +162050,7 @@
 		"levelNum": 14,
 		"songID": "S19d35e0e75afbb825d3",
 		"versions": [
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -162102,8 +162080,7 @@
 		"levelNum": 17,
 		"songID": "S19d35e0e75afbb825d3",
 		"versions": [
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -162118,8 +162095,7 @@
 		"levelNum": 2,
 		"songID": "S19d35e0e75afbb825d3",
 		"versions": [
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -162134,8 +162110,7 @@
 		"levelNum": 9,
 		"songID": "S19d35e0e75b30493c2f",
 		"versions": [
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -162150,8 +162125,7 @@
 		"levelNum": 14,
 		"songID": "S19d35e0e75b30493c2f",
 		"versions": [
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -162181,8 +162155,7 @@
 		"levelNum": 17,
 		"songID": "S19d35e0e75b30493c2f",
 		"versions": [
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{
@@ -162197,8 +162170,7 @@
 		"levelNum": 3,
 		"songID": "S19d35e0e75b30493c2f",
 		"versions": [
-			"exceed",
-			"nabla"
+			"exceed"
 		]
 	},
 	{

--- a/db/seeds/charts-sdvx.json
+++ b/db/seeds/charts-sdvx.json
@@ -191747,5 +191747,245 @@
 		"versions": [
 			"nabla"
 		]
+	},
+	{
+		"data": {
+			"inGameID": 2298
+		},
+		"difficulty": "ADV",
+		"id": "C19f6b1cd40c50ddbc0b",
+		"isPrimary": true,
+		"legacyChartID": "0637318b9c2da521736702d1e991cc7084460ab0",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19f6b1cd40a179fcdda",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2298
+		},
+		"difficulty": "EXH",
+		"id": "C19f6b1cd40c300f6c4d",
+		"isPrimary": true,
+		"legacyChartID": "f499c04df1cd73ddf06dfa91d2f5394e0a6b4e67",
+		"level": "16",
+		"levelNum": 16,
+		"songID": "S19f6b1cd40a179fcdda",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2298
+		},
+		"difficulty": "MXM",
+		"id": "C19f6b1cd40cc2acba26",
+		"isPrimary": true,
+		"legacyChartID": "66bc4d26c663ac7a25e23468223c24957f34ba59",
+		"level": "18.2",
+		"levelNum": 18.2,
+		"songID": "S19f6b1cd40a179fcdda",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2298
+		},
+		"difficulty": "NOV",
+		"id": "C19f6b1cd40c4cfab399",
+		"isPrimary": true,
+		"legacyChartID": "bf13d175a7f52b23aea3f2b52451fd2e704d91dd",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19f6b1cd40a179fcdda",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2304
+		},
+		"difficulty": "ADV",
+		"id": "C19f6b1cd40dd8eec655",
+		"isPrimary": true,
+		"legacyChartID": "ed5bfdf49856aa1b444bcb13032fe5909f7a2d94",
+		"level": "12",
+		"levelNum": 12,
+		"songID": "S19f6b1cd40d41888f9b",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2304
+		},
+		"difficulty": "EXH",
+		"id": "C19f6b1cd40ddd3d245f",
+		"isPrimary": true,
+		"legacyChartID": "df8a3140c4673ad9bdd78c2f472fee42ad74c66a",
+		"level": "15",
+		"levelNum": 15,
+		"songID": "S19f6b1cd40d41888f9b",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2304
+		},
+		"difficulty": "MXM",
+		"id": "C19f6b1cd40d2d952584",
+		"isPrimary": true,
+		"legacyChartID": "acc20011b157ae95d79f1f11ed1e5b1d9e5ecc42",
+		"level": "17.5",
+		"levelNum": 17.5,
+		"songID": "S19f6b1cd40d41888f9b",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2304
+		},
+		"difficulty": "NOV",
+		"id": "C19f6b1cd40dfb6ad2c8",
+		"isPrimary": true,
+		"legacyChartID": "d9a46b32b9ef37b9b50b7a8909f3bece5ca774dd",
+		"level": "5",
+		"levelNum": 5,
+		"songID": "S19f6b1cd40d41888f9b",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2307
+		},
+		"difficulty": "ADV",
+		"id": "C19f6b1cd40d3e7fe7f1",
+		"isPrimary": true,
+		"legacyChartID": "4263e4df923e2878b0a7dd64cb9551edd7616475",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19f6b1cd40d4247391d",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2307
+		},
+		"difficulty": "EXH",
+		"id": "C19f6b1cd40d93fdbab9",
+		"isPrimary": true,
+		"legacyChartID": "4971c964d8e47884a4702e4cc17260a8cb9a88a7",
+		"level": "16",
+		"levelNum": 16,
+		"songID": "S19f6b1cd40d4247391d",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2307
+		},
+		"difficulty": "MXM",
+		"id": "C19f6b1cd40d92084e1e",
+		"isPrimary": true,
+		"legacyChartID": "1f8acc2d0c17ee6076cda50780eead7608dd2ad7",
+		"level": "18.7",
+		"levelNum": 18.7,
+		"songID": "S19f6b1cd40d4247391d",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2307
+		},
+		"difficulty": "NOV",
+		"id": "C19f6b1cd40d58ace82f",
+		"isPrimary": true,
+		"legacyChartID": "9453961953418de3a87329fd98ce0b468c341011",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19f6b1cd40d4247391d",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2311
+		},
+		"difficulty": "ADV",
+		"id": "C19f6b1cd40d283dc9a3",
+		"isPrimary": true,
+		"legacyChartID": "e95e22ed09126794240de0e8103f883e5d97a89c",
+		"level": "13",
+		"levelNum": 13,
+		"songID": "S19f6b1cd40d7b495efd",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2311
+		},
+		"difficulty": "EXH",
+		"id": "C19f6b1cd40d2dc01f5f",
+		"isPrimary": true,
+		"legacyChartID": "765b15d515c9bad8b973fbd8e58d0876713a318b",
+		"level": "16",
+		"levelNum": 16,
+		"songID": "S19f6b1cd40d7b495efd",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2311
+		},
+		"difficulty": "MXM",
+		"id": "C19f6b1cd40d8e9a6c49",
+		"isPrimary": true,
+		"legacyChartID": "b443cb452fd4c276c4701c389a4bd1432f9853a9",
+		"level": "18.6",
+		"levelNum": 18.6,
+		"songID": "S19f6b1cd40d7b495efd",
+		"versions": [
+			"nabla"
+		]
+	},
+	{
+		"data": {
+			"inGameID": 2311
+		},
+		"difficulty": "NOV",
+		"id": "C19f6b1cd40ddbe6258a",
+		"isPrimary": true,
+		"legacyChartID": "b10fe4fef720b2e397f1e7c9e991b4e779b55399",
+		"level": "6",
+		"levelNum": 6,
+		"songID": "S19f6b1cd40d7b495efd",
+		"versions": [
+			"nabla"
+		]
 	}
 ]

--- a/db/seeds/songs-sdvx.json
+++ b/db/seeds/songs-sdvx.json
@@ -30025,5 +30025,57 @@
 			"smintheus_tan1chu"
 		],
 		"title": "Smintheus"
+	},
+	{
+		"altTitles": [],
+		"artist": "Laur",
+		"data": {
+			"displayVersion": "nabla"
+		},
+		"id": "S19f6b1cd40a179fcdda",
+		"legacySongID": 2525,
+		"searchTerms": [
+			"dizzyechoes_laur"
+		],
+		"title": "Dizzy Echoes"
+	},
+	{
+		"altTitles": [],
+		"artist": "みーに feat. 春瀬愛羅＆味醂いろは",
+		"data": {
+			"displayVersion": "nabla"
+		},
+		"id": "S19f6b1cd40d41888f9b",
+		"legacySongID": 2526,
+		"searchTerms": [
+			"unisonnadays_miini"
+		],
+		"title": "ユニゾンなデイズ♪"
+	},
+	{
+		"altTitles": [],
+		"artist": "rein jack x mernon",
+		"data": {
+			"displayVersion": "nabla"
+		},
+		"id": "S19f6b1cd40d4247391d",
+		"legacySongID": 2527,
+		"searchTerms": [
+			"meltedenergy_reinjackmernon"
+		],
+		"title": "Melted Energy"
+	},
+	{
+		"altTitles": [],
+		"artist": "原木シィタケ＋Aoi",
+		"data": {
+			"displayVersion": "nabla"
+		},
+		"id": "S19f6b1cd40d7b495efd",
+		"legacySongID": 2528,
+		"searchTerms": [
+			"tracklaundering_genbokuaoi"
+		],
+		"title": "Track Laundering"
 	}
 ]


### PR DESCRIPTION
Four new songs were added:
- Dizzy Echoes - Laur
- ユニゾンなデイズ♪ - みーに feat. 春瀬愛羅＆味醂いろは
- Melted Energy - rein jack x mernon
- Track Laundering - 原木シィタケ＋Aoi

Additionally, the `nabla` version tag has been removed from the charts of seven songs which were removed from the game (some were removed in this update, others were removed earlier):
- ユニバーページ（i-world Mix）- Remixed by BEMANI Sound Team "Yvya" feat. かなたん
- かくしん的☆めたまるふぉ～ぜっ！（crabMixx） - 土間うまる（CV.田中あいみ） Remixed by いぬ
- 鏡面の波（ramble mix） - YURiKA Remixed by BEMANI Sound Team "DJ TOTTO"
- ふ・れ・ん・ど・し・た・い（WEREHEREMIX) - Remixed by ボルテ学園生活部
- Daydream café (Euro Hopping Mix) - Remixed by BEMANI Sound Team "TAG" feat. ななひら
- Redo／アニメ「Re:ゼロから始める異世界生活」より - 鈴木このみ
- Realize／アニメ「Re:ゼロから始める異世界生活」より - 鈴木このみ