### PR TITLE
Discord embed empty games list fix

### DIFF
--- a/typescript/bot/src/slash-commands/commands/sync.ts
+++ b/typescript/bot/src/slash-commands/commands/sync.ts
@@ -1,12 +1,11 @@
-import { Env, ServerConfig } from "#config";
+import { ServerConfig } from "#config";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { ExpectedErr } from "bliss";
 
 import type { SlashCommand } from "../types";
 
 import { ACTION_Sync } from "../../actions/sync";
-import { CreateEmbed } from "../../utils/embeds";
-import { Pluralise } from "../../utils/misc";
+import { CreateImportEmbedFromSyncResult } from "../../utils/embeds";
 
 const choices: Array<[string, string]> = (
 	[
@@ -60,16 +59,7 @@ const command: SlashCommand = {
 				{ import_type, "!api_token": requestingUser.api_token },
 			);
 
-			return CreateEmbed()
-				.setTitle(
-					`Imported ${result.score_count} ${Pluralise(result.score_count, "score")}!`,
-				)
-				.addField("Created Sessions", result.session_count.toString(), true)
-				.addField("Errors", result.error_count.toString(), true)
-				.addField(
-					"Your Profile",
-					`${Env.TACHI_SERVER_LOCATION}/u/${result.user_id}/games/${result.games[0]}`,
-				);
+			return CreateImportEmbedFromSyncResult(result);
 		} catch (e) {
 			if (ExpectedErr.is(e)) {
 				return e.reason;

--- a/typescript/bot/src/utils/embeds.test.ts
+++ b/typescript/bot/src/utils/embeds.test.ts
@@ -1,0 +1,45 @@
+import type { ImportDocument } from "tachi-common";
+
+import { Env } from "#config";
+import { MessageEmbed } from "discord.js";
+import { describe, expect, it } from "vitest";
+
+import { CreateImportEmbed } from "./embeds";
+
+function makeImportDoc(overrides: Partial<ImportDocument> = {}): ImportDocument {
+	return {
+		importID: "import-abc-123",
+		userID: 42,
+		gameGroup: "iidx",
+		games: ["iidx-sp"],
+		scoreIDs: ["s1", "s2"],
+		createdSessions: [{ sessionID: "sess1", type: "Created" }],
+		errors: [],
+		classDeltas: [],
+		goalInfo: [],
+		questInfo: [],
+		...overrides,
+	} as unknown as ImportDocument;
+}
+
+function getProfileField(embed: MessageEmbed) {
+	return embed.fields?.find((field) => field.name === "Your Profile");
+}
+
+describe("CreateImportEmbed", () => {
+	it("includes the game in Your Profile when games are returned", () => {
+		const embed = CreateImportEmbed(makeImportDoc());
+
+		expect(embed).toBeInstanceOf(MessageEmbed);
+		expect(embed.title).toBe("Imported 2 scores!");
+		expect(getProfileField(embed)?.value).toBe(
+			`${Env.TACHI_SERVER_LOCATION}/u/42/games/iidx-sp`,
+		);
+	});
+
+	it("omits the game segment from Your Profile when games is empty", () => {
+		const embed = CreateImportEmbed(makeImportDoc({ games: [] }));
+
+		expect(getProfileField(embed)?.value).toBe(`${Env.TACHI_SERVER_LOCATION}/u/42`);
+	});
+});

--- a/typescript/bot/src/utils/embeds.ts
+++ b/typescript/bot/src/utils/embeds.ts
@@ -18,20 +18,50 @@ export function CreateEmbed(userID?: integer) {
 	return embed;
 }
 
-export function CreateImportEmbed(importDoc: ImportDocument) {
+function buildImportResultEmbed(
+	userID: integer,
+	games: ImportDocument["games"],
+	scoreCount: number,
+	sessionCount: number,
+	errorCount: number,
+) {
+	const profileUrl =
+		games.length > 0
+			? `${Env.TACHI_SERVER_LOCATION}/u/${userID}/games/${games[0]}`
+			: `${Env.TACHI_SERVER_LOCATION}/u/${userID}`;
+
 	return CreateEmbed()
-		.setTitle(
-			`Imported ${importDoc.scoreIDs.length} ${Pluralise(
-				importDoc.scoreIDs.length,
-				"score",
-			)}!`,
-		)
-		.addField("Created Sessions", importDoc.createdSessions.length.toString(), true)
-		.addField("Errors", importDoc.errors.length.toString(), true)
-		.addField(
-			"Your Profile",
-			`${Env.TACHI_SERVER_LOCATION}/u/${importDoc.userID}/games/${importDoc.games[0]}`,
-		);
+		.setTitle(`Imported ${scoreCount} ${Pluralise(scoreCount, "score")}!`)
+		.addField("Created Sessions", sessionCount.toString(), true)
+		.addField("Errors", errorCount.toString(), true)
+		.addField("Your Profile", profileUrl);
+}
+
+export function CreateImportEmbed(importDoc: ImportDocument) {
+	return buildImportResultEmbed(
+		importDoc.userID,
+		importDoc.games,
+		importDoc.scoreIDs.length,
+		importDoc.createdSessions.length,
+		importDoc.errors.length,
+	);
+}
+
+/** Same embed as {@link CreateImportEmbed}, built from the `/sync` action summary. */
+export function CreateImportEmbedFromSyncResult(result: {
+	error_count: number;
+	games: string[];
+	score_count: number;
+	session_count: number;
+	user_id: integer;
+}) {
+	return buildImportResultEmbed(
+		result.user_id,
+		result.games as ImportDocument["games"],
+		result.score_count,
+		result.session_count,
+		result.error_count,
+	);
 }
 
 export function CreateUserEmbed(userDoc: UserDocument) {


### PR DESCRIPTION
Changed so that if the games array is empty, the part of the URL starting with /games will be omitted, going to the user's profile instead. Centralizing import embed logic into embeds.ts to remove duplicated logic. sync.ts will now call CreateImportEmbedFromSyncResult().