### PR TITLE
Add missing song lengths and inGameIDs for Ongeki Refrech Act 1 seeds

### DIFF
--- a/db/seeds/charts-ongeki.json
+++ b/db/seeds/charts-ongeki.json
@@ -5568,7 +5568,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/01/01055exp.htm",
 			"displayVersion": "オンゲキ",
 			"inGameID": 78,
 			"isBonusTrack": false,
@@ -6975,7 +6974,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/01/01044exp.htm",
 			"displayVersion": "オンゲキ",
 			"inGameID": 68,
 			"isBonusTrack": false,
@@ -7290,7 +7288,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/01/01047exp.htm",
 			"displayVersion": "オンゲキ",
 			"inGameID": 71,
 			"isBonusTrack": false,
@@ -7427,7 +7424,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/luna/01048luna.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 8189,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2948
 		},
@@ -15024,7 +15021,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/01/01163exp.htm",
 			"displayVersion": "オンゲキ PLUS",
 			"inGameID": 192,
 			"isBonusTrack": false,
@@ -19120,7 +19116,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/02/02014exp.htm",
 			"displayVersion": "オンゲキ SUMMER",
 			"inGameID": 252,
 			"isBonusTrack": false,
@@ -30309,7 +30304,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/02/02144exp.htm",
 			"displayVersion": "オンゲキ SUMMER PLUS",
 			"inGameID": 387,
 			"isBonusTrack": false,
@@ -41409,7 +41403,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/03/03093exp.htm",
 			"displayVersion": "オンゲキ R.E.D. PLUS",
 			"inGameID": 502,
 			"isBonusTrack": false,
@@ -41848,7 +41841,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/03/03098exp.htm",
 			"displayVersion": "オンゲキ R.E.D. PLUS",
 			"inGameID": 507,
 			"isBonusTrack": false,
@@ -45816,7 +45808,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/03/03139exp.htm",
 			"displayVersion": "オンゲキ R.E.D. PLUS",
 			"inGameID": 546,
 			"isBonusTrack": false,
@@ -59727,7 +59718,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/04/04076exp.htm",
 			"displayVersion": "オンゲキ bright",
 			"inGameID": 681,
 			"isBonusTrack": false,
@@ -60287,7 +60277,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/04/04082exp.htm",
 			"displayVersion": "オンゲキ bright",
 			"inGameID": 675,
 			"isBonusTrack": false,
@@ -62838,7 +62827,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/04/04106exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
 			"inGameID": 774,
 			"isBonusTrack": false,
@@ -75452,7 +75440,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/04/04213exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.2",
 			"inGameID": 834,
 			"isBonusTrack": false,
@@ -89105,7 +89092,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/04/04323exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.3",
 			"inGameID": 1017,
 			"isBonusTrack": false,
@@ -89962,7 +89948,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/04/04331exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.3",
 			"inGameID": 1024,
 			"isBonusTrack": false,
@@ -92580,7 +92565,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/04/04362exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.3",
 			"inGameID": 1054,
 			"isBonusTrack": false,
@@ -97789,7 +97773,6 @@
 	},
 	{
 		"data": {
-			"chartViewURL": "https://sdvx.in/ongeki/05/05052exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
 			"inGameID": 1109,
 			"isBonusTrack": false,
@@ -98525,7 +98508,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1114,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1328
 		},
@@ -98544,7 +98527,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1114,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1312
 		},
@@ -98564,7 +98547,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05055exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1114,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2732
 		},
@@ -98584,7 +98567,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05055mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1114,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3276
 		},
@@ -98603,7 +98586,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1115,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 974
 		},
@@ -98622,7 +98605,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1115,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 766
 		},
@@ -98642,7 +98625,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05056exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1115,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2350
 		},
@@ -98662,7 +98645,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05056mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1115,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3840
 		},
@@ -98681,7 +98664,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1116,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1114
 		},
@@ -98700,7 +98683,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1116,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 706
 		},
@@ -98720,7 +98703,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05057exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1116,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2224
 		},
@@ -98740,7 +98723,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05057mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1116,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2586
 		},
@@ -98759,7 +98742,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1117,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1216
 		},
@@ -98778,7 +98761,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1117,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 842
 		},
@@ -98798,7 +98781,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05058exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1117,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2146
 		},
@@ -98818,7 +98801,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05058mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1117,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2844
 		},
@@ -98837,7 +98820,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1118,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1362
 		},
@@ -98856,7 +98839,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1118,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 768
 		},
@@ -98876,7 +98859,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05059exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1118,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2112
 		},
@@ -98896,7 +98879,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05059mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1118,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3000
 		},
@@ -98915,7 +98898,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1119,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1014
 		},
@@ -98934,7 +98917,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1119,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 602
 		},
@@ -98954,7 +98937,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05060exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1119,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2048
 		},
@@ -98974,7 +98957,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05060mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1119,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2652
 		},
@@ -98994,7 +98977,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05061adv.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1120,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2088
 		},
@@ -99013,7 +98996,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1120,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1120
 		},
@@ -99033,7 +99016,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05061exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1120,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2440
 		},
@@ -99053,7 +99036,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05061mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1120,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 4396
 		},
@@ -99072,7 +99055,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1121,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1206
 		},
@@ -99091,7 +99074,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1121,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 630
 		},
@@ -99110,7 +99093,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1121,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1654
 		},
@@ -99130,7 +99113,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05062mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1121,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2512
 		},
@@ -99149,7 +99132,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1122,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 678
 		},
@@ -99168,7 +99151,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1122,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 530
 		},
@@ -99187,7 +99170,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1122,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1174
 		},
@@ -99207,7 +99190,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05063mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1122,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2222
 		},
@@ -99226,7 +99209,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1124,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1424
 		},
@@ -99245,7 +99228,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1124,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1200
 		},
@@ -99265,7 +99248,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05064exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1124,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2008
 		},
@@ -99285,7 +99268,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05064mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1124,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3024
 		},
@@ -99304,7 +99287,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1125,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1204
 		},
@@ -99323,7 +99306,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1125,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 998
 		},
@@ -99343,7 +99326,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05066exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1125,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2140
 		},
@@ -99363,7 +99346,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05066mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1125,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3246
 		},
@@ -99382,7 +99365,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1126,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1092
 		},
@@ -99401,7 +99384,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1126,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 492
 		},
@@ -99421,7 +99404,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05065exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1126,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2272
 		},
@@ -99441,7 +99424,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05065mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1126,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2834
 		},
@@ -99460,7 +99443,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1127,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 844
 		},
@@ -99479,7 +99462,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1127,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 882
 		},
@@ -99498,7 +99481,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1127,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1306
 		},
@@ -99518,7 +99501,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05067mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1127,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1858
 		},
@@ -99537,7 +99520,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1128,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 652
 		},
@@ -99556,7 +99539,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1128,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 534
 		},
@@ -99575,7 +99558,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1128,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1206
 		},
@@ -99595,7 +99578,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05068mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1128,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2352
 		},
@@ -99614,7 +99597,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1129,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 984
 		},
@@ -99633,7 +99616,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1129,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 636
 		},
@@ -99652,7 +99635,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1129,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1400
 		},
@@ -99672,7 +99655,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05069mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1129,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2296
 		},
@@ -99691,7 +99674,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1130,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1546
 		},
@@ -99710,7 +99693,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1130,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 772
 		},
@@ -99730,7 +99713,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05070exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1130,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2948
 		},
@@ -99750,7 +99733,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05070mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1130,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2906
 		},
@@ -99769,7 +99752,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1131,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1946
 		},
@@ -99788,7 +99771,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1131,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1140
 		},
@@ -99808,7 +99791,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05071exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1131,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3388
 		},
@@ -99828,7 +99811,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05071mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1131,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 4520
 		},
@@ -99847,7 +99830,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1132,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1126
 		},
@@ -99866,7 +99849,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1132,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 660
 		},
@@ -99886,7 +99869,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05073exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1132,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2018
 		},
@@ -99906,7 +99889,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05073mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1132,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2266
 		},
@@ -99925,7 +99908,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1133,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1130
 		},
@@ -99944,7 +99927,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1133,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 818
 		},
@@ -99964,7 +99947,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05072exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1133,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1464
 		},
@@ -99984,7 +99967,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05072mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1133,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2350
 		},
@@ -100003,7 +99986,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1134,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1568
 		},
@@ -100022,7 +100005,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1134,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 932
 		},
@@ -100041,7 +100024,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1134,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2388
 		},
@@ -100061,7 +100044,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05074mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1134,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3760
 		},
@@ -100080,7 +100063,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1135,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 916
 		},
@@ -100099,7 +100082,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1135,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 678
 		},
@@ -100118,7 +100101,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1135,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1426
 		},
@@ -100138,7 +100121,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05075mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1135,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2000
 		},
@@ -100157,7 +100140,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1136,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1572
 		},
@@ -100176,7 +100159,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1136,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1116
 		},
@@ -100195,7 +100178,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1136,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2200
 		},
@@ -100215,7 +100198,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05076mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1136,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3348
 		},
@@ -100234,7 +100217,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1137,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2350
 		},
@@ -100253,7 +100236,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1137,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1060
 		},
@@ -100273,7 +100256,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05077exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1137,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2400
 		},
@@ -100293,7 +100276,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05077mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1137,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3648
 		},
@@ -100312,7 +100295,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1138,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1376
 		},
@@ -100331,7 +100314,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1138,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 654
 		},
@@ -100351,7 +100334,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05078exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1138,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1906
 		},
@@ -100371,7 +100354,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05078mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1138,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3396
 		},
@@ -100390,7 +100373,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1139,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1386
 		},
@@ -100409,7 +100392,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1139,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1068
 		},
@@ -100429,7 +100412,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05079exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1139,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2232
 		},
@@ -100449,7 +100432,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05079mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1139,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3522
 		},
@@ -100468,7 +100451,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1140,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1440
 		},
@@ -100487,7 +100470,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1140,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 908
 		},
@@ -100507,7 +100490,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05080exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1140,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2376
 		},
@@ -100527,7 +100510,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05080mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1140,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2940
 		},
@@ -100546,7 +100529,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1141,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1264
 		},
@@ -100565,7 +100548,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1141,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 856
 		},
@@ -100585,7 +100568,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05081exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1141,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1916
 		},
@@ -100605,7 +100588,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05081mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1141,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3570
 		},
@@ -100624,7 +100607,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1142,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1536
 		},
@@ -100643,7 +100626,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1142,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 976
 		},
@@ -100663,7 +100646,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05082exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1142,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2570
 		},
@@ -100683,7 +100666,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05082mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1142,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3442
 		},
@@ -100702,7 +100685,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1143,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1120
 		},
@@ -100721,7 +100704,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1143,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 758
 		},
@@ -100740,7 +100723,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1143,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1640
 		},
@@ -100760,7 +100743,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05083mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1143,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2920
 		},
@@ -100779,7 +100762,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1144,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1320
 		},
@@ -100798,7 +100781,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1144,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 862
 		},
@@ -100818,7 +100801,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05084exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1144,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2188
 		},
@@ -100838,7 +100821,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05084mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1144,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3194
 		},
@@ -100857,7 +100840,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1145,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1230
 		},
@@ -100876,7 +100859,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1145,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 674
 		},
@@ -100896,7 +100879,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05085exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1145,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1984
 		},
@@ -100916,7 +100899,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05085mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1145,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3520
 		},
@@ -100935,7 +100918,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1146,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 868
 		},
@@ -100954,7 +100937,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1146,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 582
 		},
@@ -100974,7 +100957,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05086exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1146,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1410
 		},
@@ -100994,7 +100977,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05086mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1146,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2336
 		},
@@ -101013,7 +100996,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1147,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 984
 		},
@@ -101032,7 +101015,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1147,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 654
 		},
@@ -101051,7 +101034,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1147,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1792
 		},
@@ -101071,7 +101054,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05087mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1147,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2440
 		},
@@ -101090,7 +101073,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1148,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1282
 		},
@@ -101109,7 +101092,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1148,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 742
 		},
@@ -101128,7 +101111,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1148,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1980
 		},
@@ -101148,7 +101131,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05090mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1148,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2852
 		},
@@ -101167,7 +101150,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1149,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 842
 		},
@@ -101186,7 +101169,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1149,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 808
 		},
@@ -101206,7 +101189,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05091exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1149,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1428
 		},
@@ -101226,7 +101209,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05091mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1149,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2676
 		},
@@ -101245,7 +101228,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1150,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 944
 		},
@@ -101264,7 +101247,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1150,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 458
 		},
@@ -101284,7 +101267,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05088exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1150,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1436
 		},
@@ -101304,7 +101287,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05088mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1150,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2282
 		},
@@ -101323,7 +101306,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1151,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1622
 		},
@@ -101342,7 +101325,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1151,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 990
 		},
@@ -101362,7 +101345,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05089exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1151,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2340
 		},
@@ -101382,7 +101365,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05089mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1151,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3354
 		},
@@ -101401,7 +101384,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1156,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1450
 		},
@@ -101420,7 +101403,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1156,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1144
 		},
@@ -101439,7 +101422,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1156,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2002
 		},
@@ -101459,7 +101442,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05092mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1156,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 4734
 		},
@@ -101478,7 +101461,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1157,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1114
 		},
@@ -101497,7 +101480,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1157,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 926
 		},
@@ -101517,7 +101500,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05093exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1157,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2414
 		},
@@ -101537,7 +101520,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05093mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1157,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3596
 		},
@@ -101556,7 +101539,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1158,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 922
 		},
@@ -101575,7 +101558,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1158,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 864
 		},
@@ -101595,7 +101578,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05094exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1158,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1892
 		},
@@ -101615,7 +101598,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05094mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1158,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3060
 		},
@@ -101634,7 +101617,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1159,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 1178
 		},
@@ -101653,7 +101636,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1159,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 968
 		},
@@ -101673,7 +101656,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05095exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1159,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 2138
 		},
@@ -101693,7 +101676,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05095mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": 1159,
+			"inGameID": null,
 			"isBonusTrack": false,
 			"maxPlatScore": 3022
 		},
@@ -101712,7 +101695,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7063,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 1236
 		},
@@ -101731,7 +101714,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7063,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 672
 		},
@@ -101750,7 +101733,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7063,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 1754
 		},
@@ -101770,7 +101753,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/02/02054mst.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7063,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 2600
 		},
@@ -101789,7 +101772,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7064,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 1236
 		},
@@ -101808,7 +101791,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7064,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 672
 		},
@@ -101827,7 +101810,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7064,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 1754
 		},
@@ -101847,7 +101830,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/02/02054mst.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7064,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 2600
 		},
@@ -101866,7 +101849,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7065,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 1236
 		},
@@ -101885,7 +101868,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7065,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 672
 		},
@@ -101904,7 +101887,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7065,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 1754
 		},
@@ -101924,7 +101907,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/02/02054mst.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": 7065,
+			"inGameID": null,
 			"isBonusTrack": true,
 			"maxPlatScore": 2600
 		},

--- a/db/seeds/charts-ongeki.json
+++ b/db/seeds/charts-ongeki.json
@@ -5568,6 +5568,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/01/01055exp.htm",
 			"displayVersion": "オンゲキ",
 			"inGameID": 78,
 			"isBonusTrack": false,
@@ -6974,6 +6975,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/01/01044exp.htm",
 			"displayVersion": "オンゲキ",
 			"inGameID": 68,
 			"isBonusTrack": false,
@@ -7288,6 +7290,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/01/01047exp.htm",
 			"displayVersion": "オンゲキ",
 			"inGameID": 71,
 			"isBonusTrack": false,
@@ -7424,7 +7427,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/luna/01048luna.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 8189,
 			"isBonusTrack": false,
 			"maxPlatScore": 2948
 		},
@@ -15021,6 +15024,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/01/01163exp.htm",
 			"displayVersion": "オンゲキ PLUS",
 			"inGameID": 192,
 			"isBonusTrack": false,
@@ -19116,6 +19120,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/02/02014exp.htm",
 			"displayVersion": "オンゲキ SUMMER",
 			"inGameID": 252,
 			"isBonusTrack": false,
@@ -30304,6 +30309,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/02/02144exp.htm",
 			"displayVersion": "オンゲキ SUMMER PLUS",
 			"inGameID": 387,
 			"isBonusTrack": false,
@@ -41403,6 +41409,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/03/03093exp.htm",
 			"displayVersion": "オンゲキ R.E.D. PLUS",
 			"inGameID": 502,
 			"isBonusTrack": false,
@@ -41841,6 +41848,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/03/03098exp.htm",
 			"displayVersion": "オンゲキ R.E.D. PLUS",
 			"inGameID": 507,
 			"isBonusTrack": false,
@@ -45808,6 +45816,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/03/03139exp.htm",
 			"displayVersion": "オンゲキ R.E.D. PLUS",
 			"inGameID": 546,
 			"isBonusTrack": false,
@@ -59718,6 +59727,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/04/04076exp.htm",
 			"displayVersion": "オンゲキ bright",
 			"inGameID": 681,
 			"isBonusTrack": false,
@@ -60277,6 +60287,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/04/04082exp.htm",
 			"displayVersion": "オンゲキ bright",
 			"inGameID": 675,
 			"isBonusTrack": false,
@@ -62827,6 +62838,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/04/04106exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
 			"inGameID": 774,
 			"isBonusTrack": false,
@@ -75440,6 +75452,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/04/04213exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.2",
 			"inGameID": 834,
 			"isBonusTrack": false,
@@ -89092,6 +89105,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/04/04323exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.3",
 			"inGameID": 1017,
 			"isBonusTrack": false,
@@ -89948,6 +89962,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/04/04331exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.3",
 			"inGameID": 1024,
 			"isBonusTrack": false,
@@ -92565,6 +92580,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/04/04362exp.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.3",
 			"inGameID": 1054,
 			"isBonusTrack": false,
@@ -97773,6 +97789,7 @@
 	},
 	{
 		"data": {
+			"chartViewURL": "https://sdvx.in/ongeki/05/05052exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
 			"inGameID": 1109,
 			"isBonusTrack": false,
@@ -98508,7 +98525,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1114,
 			"isBonusTrack": false,
 			"maxPlatScore": 1328
 		},
@@ -98527,7 +98544,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1114,
 			"isBonusTrack": false,
 			"maxPlatScore": 1312
 		},
@@ -98547,7 +98564,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05055exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1114,
 			"isBonusTrack": false,
 			"maxPlatScore": 2732
 		},
@@ -98567,7 +98584,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05055mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1114,
 			"isBonusTrack": false,
 			"maxPlatScore": 3276
 		},
@@ -98586,7 +98603,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1115,
 			"isBonusTrack": false,
 			"maxPlatScore": 974
 		},
@@ -98605,7 +98622,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1115,
 			"isBonusTrack": false,
 			"maxPlatScore": 766
 		},
@@ -98625,7 +98642,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05056exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1115,
 			"isBonusTrack": false,
 			"maxPlatScore": 2350
 		},
@@ -98645,7 +98662,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05056mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1115,
 			"isBonusTrack": false,
 			"maxPlatScore": 3840
 		},
@@ -98664,7 +98681,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1116,
 			"isBonusTrack": false,
 			"maxPlatScore": 1114
 		},
@@ -98683,7 +98700,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1116,
 			"isBonusTrack": false,
 			"maxPlatScore": 706
 		},
@@ -98703,7 +98720,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05057exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1116,
 			"isBonusTrack": false,
 			"maxPlatScore": 2224
 		},
@@ -98723,7 +98740,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05057mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1116,
 			"isBonusTrack": false,
 			"maxPlatScore": 2586
 		},
@@ -98742,7 +98759,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1117,
 			"isBonusTrack": false,
 			"maxPlatScore": 1216
 		},
@@ -98761,7 +98778,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1117,
 			"isBonusTrack": false,
 			"maxPlatScore": 842
 		},
@@ -98781,7 +98798,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05058exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1117,
 			"isBonusTrack": false,
 			"maxPlatScore": 2146
 		},
@@ -98801,7 +98818,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05058mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1117,
 			"isBonusTrack": false,
 			"maxPlatScore": 2844
 		},
@@ -98820,7 +98837,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1118,
 			"isBonusTrack": false,
 			"maxPlatScore": 1362
 		},
@@ -98839,7 +98856,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1118,
 			"isBonusTrack": false,
 			"maxPlatScore": 768
 		},
@@ -98859,7 +98876,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05059exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1118,
 			"isBonusTrack": false,
 			"maxPlatScore": 2112
 		},
@@ -98879,7 +98896,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05059mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1118,
 			"isBonusTrack": false,
 			"maxPlatScore": 3000
 		},
@@ -98898,7 +98915,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1119,
 			"isBonusTrack": false,
 			"maxPlatScore": 1014
 		},
@@ -98917,7 +98934,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1119,
 			"isBonusTrack": false,
 			"maxPlatScore": 602
 		},
@@ -98937,7 +98954,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05060exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1119,
 			"isBonusTrack": false,
 			"maxPlatScore": 2048
 		},
@@ -98957,7 +98974,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05060mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1119,
 			"isBonusTrack": false,
 			"maxPlatScore": 2652
 		},
@@ -98977,7 +98994,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05061adv.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1120,
 			"isBonusTrack": false,
 			"maxPlatScore": 2088
 		},
@@ -98996,7 +99013,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1120,
 			"isBonusTrack": false,
 			"maxPlatScore": 1120
 		},
@@ -99016,7 +99033,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05061exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1120,
 			"isBonusTrack": false,
 			"maxPlatScore": 2440
 		},
@@ -99036,7 +99053,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05061mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1120,
 			"isBonusTrack": false,
 			"maxPlatScore": 4396
 		},
@@ -99055,7 +99072,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1121,
 			"isBonusTrack": false,
 			"maxPlatScore": 1206
 		},
@@ -99074,7 +99091,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1121,
 			"isBonusTrack": false,
 			"maxPlatScore": 630
 		},
@@ -99093,7 +99110,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1121,
 			"isBonusTrack": false,
 			"maxPlatScore": 1654
 		},
@@ -99113,7 +99130,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05062mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1121,
 			"isBonusTrack": false,
 			"maxPlatScore": 2512
 		},
@@ -99132,7 +99149,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1122,
 			"isBonusTrack": false,
 			"maxPlatScore": 678
 		},
@@ -99151,7 +99168,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1122,
 			"isBonusTrack": false,
 			"maxPlatScore": 530
 		},
@@ -99170,7 +99187,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1122,
 			"isBonusTrack": false,
 			"maxPlatScore": 1174
 		},
@@ -99190,7 +99207,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05063mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1122,
 			"isBonusTrack": false,
 			"maxPlatScore": 2222
 		},
@@ -99209,7 +99226,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1124,
 			"isBonusTrack": false,
 			"maxPlatScore": 1424
 		},
@@ -99228,7 +99245,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1124,
 			"isBonusTrack": false,
 			"maxPlatScore": 1200
 		},
@@ -99248,7 +99265,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05064exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1124,
 			"isBonusTrack": false,
 			"maxPlatScore": 2008
 		},
@@ -99268,7 +99285,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05064mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1124,
 			"isBonusTrack": false,
 			"maxPlatScore": 3024
 		},
@@ -99287,7 +99304,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1125,
 			"isBonusTrack": false,
 			"maxPlatScore": 1204
 		},
@@ -99306,7 +99323,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1125,
 			"isBonusTrack": false,
 			"maxPlatScore": 998
 		},
@@ -99326,7 +99343,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05066exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1125,
 			"isBonusTrack": false,
 			"maxPlatScore": 2140
 		},
@@ -99346,7 +99363,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05066mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1125,
 			"isBonusTrack": false,
 			"maxPlatScore": 3246
 		},
@@ -99365,7 +99382,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1126,
 			"isBonusTrack": false,
 			"maxPlatScore": 1092
 		},
@@ -99384,7 +99401,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1126,
 			"isBonusTrack": false,
 			"maxPlatScore": 492
 		},
@@ -99404,7 +99421,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05065exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1126,
 			"isBonusTrack": false,
 			"maxPlatScore": 2272
 		},
@@ -99424,7 +99441,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05065mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1126,
 			"isBonusTrack": false,
 			"maxPlatScore": 2834
 		},
@@ -99443,7 +99460,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1127,
 			"isBonusTrack": false,
 			"maxPlatScore": 844
 		},
@@ -99462,7 +99479,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1127,
 			"isBonusTrack": false,
 			"maxPlatScore": 882
 		},
@@ -99481,7 +99498,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1127,
 			"isBonusTrack": false,
 			"maxPlatScore": 1306
 		},
@@ -99501,7 +99518,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05067mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1127,
 			"isBonusTrack": false,
 			"maxPlatScore": 1858
 		},
@@ -99520,7 +99537,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1128,
 			"isBonusTrack": false,
 			"maxPlatScore": 652
 		},
@@ -99539,7 +99556,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1128,
 			"isBonusTrack": false,
 			"maxPlatScore": 534
 		},
@@ -99558,7 +99575,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1128,
 			"isBonusTrack": false,
 			"maxPlatScore": 1206
 		},
@@ -99578,7 +99595,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05068mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1128,
 			"isBonusTrack": false,
 			"maxPlatScore": 2352
 		},
@@ -99597,7 +99614,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1129,
 			"isBonusTrack": false,
 			"maxPlatScore": 984
 		},
@@ -99616,7 +99633,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1129,
 			"isBonusTrack": false,
 			"maxPlatScore": 636
 		},
@@ -99635,7 +99652,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1129,
 			"isBonusTrack": false,
 			"maxPlatScore": 1400
 		},
@@ -99655,7 +99672,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05069mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1129,
 			"isBonusTrack": false,
 			"maxPlatScore": 2296
 		},
@@ -99674,7 +99691,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1130,
 			"isBonusTrack": false,
 			"maxPlatScore": 1546
 		},
@@ -99693,7 +99710,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1130,
 			"isBonusTrack": false,
 			"maxPlatScore": 772
 		},
@@ -99713,7 +99730,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05070exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1130,
 			"isBonusTrack": false,
 			"maxPlatScore": 2948
 		},
@@ -99733,7 +99750,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05070mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1130,
 			"isBonusTrack": false,
 			"maxPlatScore": 2906
 		},
@@ -99752,7 +99769,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1131,
 			"isBonusTrack": false,
 			"maxPlatScore": 1946
 		},
@@ -99771,7 +99788,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1131,
 			"isBonusTrack": false,
 			"maxPlatScore": 1140
 		},
@@ -99791,7 +99808,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05071exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1131,
 			"isBonusTrack": false,
 			"maxPlatScore": 3388
 		},
@@ -99811,7 +99828,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05071mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1131,
 			"isBonusTrack": false,
 			"maxPlatScore": 4520
 		},
@@ -99830,7 +99847,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1132,
 			"isBonusTrack": false,
 			"maxPlatScore": 1126
 		},
@@ -99849,7 +99866,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1132,
 			"isBonusTrack": false,
 			"maxPlatScore": 660
 		},
@@ -99869,7 +99886,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05073exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1132,
 			"isBonusTrack": false,
 			"maxPlatScore": 2018
 		},
@@ -99889,7 +99906,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05073mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1132,
 			"isBonusTrack": false,
 			"maxPlatScore": 2266
 		},
@@ -99908,7 +99925,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1133,
 			"isBonusTrack": false,
 			"maxPlatScore": 1130
 		},
@@ -99927,7 +99944,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1133,
 			"isBonusTrack": false,
 			"maxPlatScore": 818
 		},
@@ -99947,7 +99964,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05072exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1133,
 			"isBonusTrack": false,
 			"maxPlatScore": 1464
 		},
@@ -99967,7 +99984,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05072mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1133,
 			"isBonusTrack": false,
 			"maxPlatScore": 2350
 		},
@@ -99986,7 +100003,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1134,
 			"isBonusTrack": false,
 			"maxPlatScore": 1568
 		},
@@ -100005,7 +100022,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1134,
 			"isBonusTrack": false,
 			"maxPlatScore": 932
 		},
@@ -100024,7 +100041,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1134,
 			"isBonusTrack": false,
 			"maxPlatScore": 2388
 		},
@@ -100044,7 +100061,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05074mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1134,
 			"isBonusTrack": false,
 			"maxPlatScore": 3760
 		},
@@ -100063,7 +100080,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1135,
 			"isBonusTrack": false,
 			"maxPlatScore": 916
 		},
@@ -100082,7 +100099,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1135,
 			"isBonusTrack": false,
 			"maxPlatScore": 678
 		},
@@ -100101,7 +100118,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1135,
 			"isBonusTrack": false,
 			"maxPlatScore": 1426
 		},
@@ -100121,7 +100138,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05075mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1135,
 			"isBonusTrack": false,
 			"maxPlatScore": 2000
 		},
@@ -100140,7 +100157,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1136,
 			"isBonusTrack": false,
 			"maxPlatScore": 1572
 		},
@@ -100159,7 +100176,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1136,
 			"isBonusTrack": false,
 			"maxPlatScore": 1116
 		},
@@ -100178,7 +100195,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1136,
 			"isBonusTrack": false,
 			"maxPlatScore": 2200
 		},
@@ -100198,7 +100215,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05076mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1136,
 			"isBonusTrack": false,
 			"maxPlatScore": 3348
 		},
@@ -100217,7 +100234,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1137,
 			"isBonusTrack": false,
 			"maxPlatScore": 2350
 		},
@@ -100236,7 +100253,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1137,
 			"isBonusTrack": false,
 			"maxPlatScore": 1060
 		},
@@ -100256,7 +100273,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05077exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1137,
 			"isBonusTrack": false,
 			"maxPlatScore": 2400
 		},
@@ -100276,7 +100293,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05077mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1137,
 			"isBonusTrack": false,
 			"maxPlatScore": 3648
 		},
@@ -100295,7 +100312,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1138,
 			"isBonusTrack": false,
 			"maxPlatScore": 1376
 		},
@@ -100314,7 +100331,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1138,
 			"isBonusTrack": false,
 			"maxPlatScore": 654
 		},
@@ -100334,7 +100351,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05078exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1138,
 			"isBonusTrack": false,
 			"maxPlatScore": 1906
 		},
@@ -100354,7 +100371,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05078mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1138,
 			"isBonusTrack": false,
 			"maxPlatScore": 3396
 		},
@@ -100373,7 +100390,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1139,
 			"isBonusTrack": false,
 			"maxPlatScore": 1386
 		},
@@ -100392,7 +100409,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1139,
 			"isBonusTrack": false,
 			"maxPlatScore": 1068
 		},
@@ -100412,7 +100429,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05079exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1139,
 			"isBonusTrack": false,
 			"maxPlatScore": 2232
 		},
@@ -100432,7 +100449,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05079mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1139,
 			"isBonusTrack": false,
 			"maxPlatScore": 3522
 		},
@@ -100451,7 +100468,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1140,
 			"isBonusTrack": false,
 			"maxPlatScore": 1440
 		},
@@ -100470,7 +100487,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1140,
 			"isBonusTrack": false,
 			"maxPlatScore": 908
 		},
@@ -100490,7 +100507,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05080exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1140,
 			"isBonusTrack": false,
 			"maxPlatScore": 2376
 		},
@@ -100510,7 +100527,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05080mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1140,
 			"isBonusTrack": false,
 			"maxPlatScore": 2940
 		},
@@ -100529,7 +100546,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1141,
 			"isBonusTrack": false,
 			"maxPlatScore": 1264
 		},
@@ -100548,7 +100565,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1141,
 			"isBonusTrack": false,
 			"maxPlatScore": 856
 		},
@@ -100568,7 +100585,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05081exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1141,
 			"isBonusTrack": false,
 			"maxPlatScore": 1916
 		},
@@ -100588,7 +100605,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05081mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1141,
 			"isBonusTrack": false,
 			"maxPlatScore": 3570
 		},
@@ -100607,7 +100624,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1142,
 			"isBonusTrack": false,
 			"maxPlatScore": 1536
 		},
@@ -100626,7 +100643,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1142,
 			"isBonusTrack": false,
 			"maxPlatScore": 976
 		},
@@ -100646,7 +100663,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05082exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1142,
 			"isBonusTrack": false,
 			"maxPlatScore": 2570
 		},
@@ -100666,7 +100683,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05082mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1142,
 			"isBonusTrack": false,
 			"maxPlatScore": 3442
 		},
@@ -100685,7 +100702,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1143,
 			"isBonusTrack": false,
 			"maxPlatScore": 1120
 		},
@@ -100704,7 +100721,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1143,
 			"isBonusTrack": false,
 			"maxPlatScore": 758
 		},
@@ -100723,7 +100740,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1143,
 			"isBonusTrack": false,
 			"maxPlatScore": 1640
 		},
@@ -100743,7 +100760,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05083mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1143,
 			"isBonusTrack": false,
 			"maxPlatScore": 2920
 		},
@@ -100762,7 +100779,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1144,
 			"isBonusTrack": false,
 			"maxPlatScore": 1320
 		},
@@ -100781,7 +100798,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1144,
 			"isBonusTrack": false,
 			"maxPlatScore": 862
 		},
@@ -100801,7 +100818,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05084exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1144,
 			"isBonusTrack": false,
 			"maxPlatScore": 2188
 		},
@@ -100821,7 +100838,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05084mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1144,
 			"isBonusTrack": false,
 			"maxPlatScore": 3194
 		},
@@ -100840,7 +100857,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1145,
 			"isBonusTrack": false,
 			"maxPlatScore": 1230
 		},
@@ -100859,7 +100876,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1145,
 			"isBonusTrack": false,
 			"maxPlatScore": 674
 		},
@@ -100879,7 +100896,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05085exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1145,
 			"isBonusTrack": false,
 			"maxPlatScore": 1984
 		},
@@ -100899,7 +100916,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05085mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1145,
 			"isBonusTrack": false,
 			"maxPlatScore": 3520
 		},
@@ -100918,7 +100935,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1146,
 			"isBonusTrack": false,
 			"maxPlatScore": 868
 		},
@@ -100937,7 +100954,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1146,
 			"isBonusTrack": false,
 			"maxPlatScore": 582
 		},
@@ -100957,7 +100974,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05086exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1146,
 			"isBonusTrack": false,
 			"maxPlatScore": 1410
 		},
@@ -100977,7 +100994,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05086mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1146,
 			"isBonusTrack": false,
 			"maxPlatScore": 2336
 		},
@@ -100996,7 +101013,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1147,
 			"isBonusTrack": false,
 			"maxPlatScore": 984
 		},
@@ -101015,7 +101032,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1147,
 			"isBonusTrack": false,
 			"maxPlatScore": 654
 		},
@@ -101034,7 +101051,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1147,
 			"isBonusTrack": false,
 			"maxPlatScore": 1792
 		},
@@ -101054,7 +101071,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05087mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1147,
 			"isBonusTrack": false,
 			"maxPlatScore": 2440
 		},
@@ -101073,7 +101090,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1148,
 			"isBonusTrack": false,
 			"maxPlatScore": 1282
 		},
@@ -101092,7 +101109,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1148,
 			"isBonusTrack": false,
 			"maxPlatScore": 742
 		},
@@ -101111,7 +101128,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1148,
 			"isBonusTrack": false,
 			"maxPlatScore": 1980
 		},
@@ -101131,7 +101148,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05090mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1148,
 			"isBonusTrack": false,
 			"maxPlatScore": 2852
 		},
@@ -101150,7 +101167,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1149,
 			"isBonusTrack": false,
 			"maxPlatScore": 842
 		},
@@ -101169,7 +101186,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1149,
 			"isBonusTrack": false,
 			"maxPlatScore": 808
 		},
@@ -101189,7 +101206,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05091exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1149,
 			"isBonusTrack": false,
 			"maxPlatScore": 1428
 		},
@@ -101209,7 +101226,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05091mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1149,
 			"isBonusTrack": false,
 			"maxPlatScore": 2676
 		},
@@ -101228,7 +101245,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1150,
 			"isBonusTrack": false,
 			"maxPlatScore": 944
 		},
@@ -101247,7 +101264,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1150,
 			"isBonusTrack": false,
 			"maxPlatScore": 458
 		},
@@ -101267,7 +101284,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05088exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1150,
 			"isBonusTrack": false,
 			"maxPlatScore": 1436
 		},
@@ -101287,7 +101304,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05088mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1150,
 			"isBonusTrack": false,
 			"maxPlatScore": 2282
 		},
@@ -101306,7 +101323,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1151,
 			"isBonusTrack": false,
 			"maxPlatScore": 1622
 		},
@@ -101325,7 +101342,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1151,
 			"isBonusTrack": false,
 			"maxPlatScore": 990
 		},
@@ -101345,7 +101362,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05089exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1151,
 			"isBonusTrack": false,
 			"maxPlatScore": 2340
 		},
@@ -101365,7 +101382,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05089mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1151,
 			"isBonusTrack": false,
 			"maxPlatScore": 3354
 		},
@@ -101384,7 +101401,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1156,
 			"isBonusTrack": false,
 			"maxPlatScore": 1450
 		},
@@ -101403,7 +101420,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1156,
 			"isBonusTrack": false,
 			"maxPlatScore": 1144
 		},
@@ -101422,7 +101439,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1156,
 			"isBonusTrack": false,
 			"maxPlatScore": 2002
 		},
@@ -101442,7 +101459,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05092mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1156,
 			"isBonusTrack": false,
 			"maxPlatScore": 4734
 		},
@@ -101461,7 +101478,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1157,
 			"isBonusTrack": false,
 			"maxPlatScore": 1114
 		},
@@ -101480,7 +101497,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1157,
 			"isBonusTrack": false,
 			"maxPlatScore": 926
 		},
@@ -101500,7 +101517,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05093exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1157,
 			"isBonusTrack": false,
 			"maxPlatScore": 2414
 		},
@@ -101520,7 +101537,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05093mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1157,
 			"isBonusTrack": false,
 			"maxPlatScore": 3596
 		},
@@ -101539,7 +101556,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1158,
 			"isBonusTrack": false,
 			"maxPlatScore": 922
 		},
@@ -101558,7 +101575,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1158,
 			"isBonusTrack": false,
 			"maxPlatScore": 864
 		},
@@ -101578,7 +101595,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05094exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1158,
 			"isBonusTrack": false,
 			"maxPlatScore": 1892
 		},
@@ -101598,7 +101615,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05094mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1158,
 			"isBonusTrack": false,
 			"maxPlatScore": 3060
 		},
@@ -101617,7 +101634,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1159,
 			"isBonusTrack": false,
 			"maxPlatScore": 1178
 		},
@@ -101636,7 +101653,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1159,
 			"isBonusTrack": false,
 			"maxPlatScore": 968
 		},
@@ -101656,7 +101673,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05095exp.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1159,
 			"isBonusTrack": false,
 			"maxPlatScore": 2138
 		},
@@ -101676,7 +101693,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/05/05095mst.htm",
 			"displayVersion": "オンゲキ Re:Fresh",
-			"inGameID": null,
+			"inGameID": 1159,
 			"isBonusTrack": false,
 			"maxPlatScore": 3022
 		},
@@ -101695,7 +101712,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7063,
 			"isBonusTrack": true,
 			"maxPlatScore": 1236
 		},
@@ -101714,7 +101731,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7063,
 			"isBonusTrack": true,
 			"maxPlatScore": 672
 		},
@@ -101733,7 +101750,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7063,
 			"isBonusTrack": true,
 			"maxPlatScore": 1754
 		},
@@ -101753,7 +101770,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/02/02054mst.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7063,
 			"isBonusTrack": true,
 			"maxPlatScore": 2600
 		},
@@ -101772,7 +101789,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7064,
 			"isBonusTrack": true,
 			"maxPlatScore": 1236
 		},
@@ -101791,7 +101808,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7064,
 			"isBonusTrack": true,
 			"maxPlatScore": 672
 		},
@@ -101810,7 +101827,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7064,
 			"isBonusTrack": true,
 			"maxPlatScore": 1754
 		},
@@ -101830,7 +101847,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/02/02054mst.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7064,
 			"isBonusTrack": true,
 			"maxPlatScore": 2600
 		},
@@ -101849,7 +101866,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7065,
 			"isBonusTrack": true,
 			"maxPlatScore": 1236
 		},
@@ -101868,7 +101885,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7065,
 			"isBonusTrack": true,
 			"maxPlatScore": 672
 		},
@@ -101887,7 +101904,7 @@
 	{
 		"data": {
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7065,
 			"isBonusTrack": true,
 			"maxPlatScore": 1754
 		},
@@ -101907,7 +101924,7 @@
 		"data": {
 			"chartViewURL": "https://sdvx.in/ongeki/02/02054mst.htm",
 			"displayVersion": "オンゲキ bright MEMORY Act.1",
-			"inGameID": null,
+			"inGameID": 7065,
 			"isBonusTrack": true,
 			"maxPlatScore": 2600
 		},

--- a/db/seeds/songs-ongeki.json
+++ b/db/seeds/songs-ongeki.json
@@ -15191,7 +15191,7 @@
 		"altTitles": [],
 		"artist": "曲：TAG／歌：井之原 小星(CV：ももの はるな)",
 		"data": {
-			"duration": null,
+			"duration": 157.895,
 			"genre": "オンゲキ"
 		},
 		"id": "S19e3332aef6eb1234e7",
@@ -15205,7 +15205,7 @@
 		"altTitles": [],
 		"artist": "曲：RD-Sounds／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
-			"duration": null,
+			"duration": 155.102,
 			"genre": "オンゲキ"
 		},
 		"id": "S19e3332aef718e843de",
@@ -15219,7 +15219,7 @@
 		"altTitles": [],
 		"artist": "igel",
 		"data": {
-			"duration": null,
+			"duration": 141.489,
 			"genre": "オンゲキ"
 		},
 		"id": "S19e3332aef86260e3b7",
@@ -15233,7 +15233,7 @@
 		"altTitles": [],
 		"artist": "安井洋介",
 		"data": {
-			"duration": null,
+			"duration": 150.103,
 			"genre": "オンゲキ"
 		},
 		"id": "S19e3332aef9ff4d8d64",
@@ -15245,7 +15245,7 @@
 		"altTitles": [],
 		"artist": "Yooh / Kobaryo",
 		"data": {
-			"duration": null,
+			"duration": 163.738,
 			"flavorGenre": "Chaotic Speedcore",
 			"genre": "オンゲキ"
 		},
@@ -15260,7 +15260,7 @@
 		"altTitles": [],
 		"artist": "Alicemetix ex-ZAQUVA",
 		"data": {
-			"duration": null,
+			"duration": 137.037,
 			"genre": "オンゲキ"
 		},
 		"id": "S19e3332aefbeb78ad51",
@@ -15272,7 +15272,7 @@
 		"altTitles": [],
 		"artist": "rintaro soma",
 		"data": {
-			"duration": null,
+			"duration": 163.404,
 			"genre": "オンゲキ"
 		},
 		"id": "S19e3332aefcaf9e7132",
@@ -15284,7 +15284,7 @@
 		"altTitles": [],
 		"artist": "蓮ノ空女学院スクールアイドルクラブ",
 		"data": {
-			"duration": null,
+			"duration": 142.222,
 			"genre": "POPS＆ANIME"
 		},
 		"id": "S19e3332aefd9c60e10c",
@@ -15296,7 +15296,7 @@
 		"altTitles": [],
 		"artist": "蓮ノ空女学院スクールアイドルクラブ",
 		"data": {
-			"duration": null,
+			"duration": 119.027,
 			"genre": "POPS＆ANIME"
 		},
 		"id": "S19e3332aefe04a2b076",
@@ -15310,7 +15310,7 @@
 		"altTitles": [],
 		"artist": "すりぃ×相沢",
 		"data": {
-			"duration": null,
+			"duration": 161.711,
 			"genre": "チュウマイ"
 		},
 		"id": "S19e3332aeff135ad48a",
@@ -15324,7 +15324,7 @@
 		"altTitles": [],
 		"artist": "Shu feat. 七海うらら",
 		"data": {
-			"duration": null,
+			"duration": 155.4,
 			"genre": "チュウマイ"
 		},
 		"id": "S19e3332af00113c17e7",
@@ -15338,7 +15338,7 @@
 		"altTitles": [],
 		"artist": "DIVELA feat.いゔどっと",
 		"data": {
-			"duration": null,
+			"duration": 141.951,
 			"genre": "チュウマイ"
 		},
 		"id": "S19e3332af01e0b4cdc4",
@@ -15352,7 +15352,7 @@
 		"altTitles": [],
 		"artist": "40mP × sasakure.UK",
 		"data": {
-			"duration": null,
+			"duration": 133.077,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af02e8bdb1e6",
@@ -15366,7 +15366,7 @@
 		"altTitles": [],
 		"artist": "じん",
 		"data": {
-			"duration": null,
+			"duration": 133.091,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af0359a15ccd",
@@ -15378,7 +15378,7 @@
 		"altTitles": [],
 		"artist": "雨良 Amala",
 		"data": {
-			"duration": null,
+			"duration": 159.231,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af04352504ca",
@@ -15393,7 +15393,7 @@
 		"altTitles": [],
 		"artist": "Zekk",
 		"data": {
-			"duration": null,
+			"duration": 149.818,
 			"flavorGenre": "MIXTURE",
 			"genre": "オンゲキ"
 		},
@@ -15406,7 +15406,7 @@
 		"altTitles": [],
 		"artist": "tn-shi",
 		"data": {
-			"duration": null,
+			"duration": 151.485,
 			"genre": "オンゲキ"
 		},
 		"id": "S19e3332af0602b00d97",
@@ -15418,7 +15418,7 @@
 		"altTitles": [],
 		"artist": "taichi hiyama",
 		"data": {
-			"duration": null,
+			"duration": 142.394,
 			"genre": "オンゲキ"
 		},
 		"id": "S19e3332af0709877b8d",
@@ -15432,7 +15432,7 @@
 		"altTitles": [],
 		"artist": "ぼっちぼろまる",
 		"data": {
-			"duration": null,
+			"duration": 140.118,
 			"genre": "チュウマイ"
 		},
 		"id": "S19e3332af089900ec7f",
@@ -15446,7 +15446,7 @@
 		"altTitles": [],
 		"artist": "Palette Project（暁月クララ、七海ロナ、常磐カナメ、藤宮コトハ、江波キョウカ、鬼多見アユム、香鳴ハノン）",
 		"data": {
-			"duration": null,
+			"duration": 154.915,
 			"genre": "POPS＆ANIME"
 		},
 		"id": "S19e3332af093304fbbe",
@@ -15460,7 +15460,7 @@
 		"altTitles": [],
 		"artist": "RouteHeart（七海ロナ・藤宮コトハ）",
 		"data": {
-			"duration": null,
+			"duration": 158.118,
 			"genre": "POPS＆ANIME"
 		},
 		"id": "S19e3332af0a32c35d59",
@@ -15474,7 +15474,7 @@
 		"altTitles": [],
 		"artist": "Sputrip（暁月クララ・香鳴ハノン・常磐カナメ）",
 		"data": {
-			"duration": null,
+			"duration": 184.941,
 			"genre": "POPS＆ANIME"
 		},
 		"id": "S19e3332af0ba9cbcb25",
@@ -15488,7 +15488,7 @@
 		"altTitles": [],
 		"artist": "REGALILIA（江波キョウカ・鬼多見アユム）",
 		"data": {
-			"duration": null,
+			"duration": 162.4,
 			"genre": "POPS＆ANIME"
 		},
 		"id": "S19e3332af0c7fc44256",
@@ -15500,7 +15500,7 @@
 		"altTitles": [],
 		"artist": "魔界都市ニイガタ（黄泉路テヂーモ×dawn-system×かゆき）",
 		"data": {
-			"duration": null,
+			"duration": 129.375,
 			"flavorGenre": "tatamiser",
 			"genre": "VARIETY"
 		},
@@ -15515,7 +15515,7 @@
 		"altTitles": [],
 		"artist": "打打だいず FEAT. 月乃",
 		"data": {
-			"duration": null,
+			"duration": 152.663,
 			"genre": "VARIETY"
 		},
 		"id": "S19e3332af0e7bd56d67",
@@ -15527,7 +15527,7 @@
 		"altTitles": [],
 		"artist": "いるかアイス × Tanchiky feat. 初音ミク",
 		"data": {
-			"duration": null,
+			"duration": 152.211,
 			"genre": "VARIETY"
 		},
 		"id": "S19e3332af0f1377c1be",
@@ -15541,7 +15541,7 @@
 		"altTitles": [],
 		"artist": "かいりきベア",
 		"data": {
-			"duration": null,
+			"duration": 159,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af10fb0a20a0",
@@ -15555,7 +15555,7 @@
 		"altTitles": [],
 		"artist": "cosMo＠暴走P",
 		"data": {
-			"duration": null,
+			"duration": 146.436,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af119595518a",
@@ -15569,7 +15569,7 @@
 		"altTitles": [],
 		"artist": "雄之助",
 		"data": {
-			"duration": null,
+			"duration": 153.882,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af12f2988b8a",
@@ -15583,7 +15583,7 @@
 		"altTitles": [],
 		"artist": "Ponchi♪ feat.初音ミク",
 		"data": {
-			"duration": null,
+			"duration": 159.948,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af13713a2c75",
@@ -15597,7 +15597,7 @@
 		"altTitles": [],
 		"artist": "かめりあ",
 		"data": {
-			"duration": null,
+			"duration": 141.159,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af14ab165ddb",
@@ -15611,7 +15611,7 @@
 		"altTitles": [],
 		"artist": "ARM＋夕野ヨシミ (IOSYS) feat.藤咲かりん",
 		"data": {
-			"duration": null,
+			"duration": 123.333,
 			"genre": "東方Project"
 		},
 		"id": "S19e3332af151516e9e5",
@@ -15626,7 +15626,7 @@
 		"altTitles": [],
 		"artist": "少女フラクタル",
 		"data": {
-			"duration": null,
+			"duration": 151.875,
 			"genre": "東方Project"
 		},
 		"id": "S19e3332af16ab6463ff",
@@ -15640,7 +15640,7 @@
 		"altTitles": [],
 		"artist": "きくお",
 		"data": {
-			"duration": null,
+			"duration": 130.696,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af172bd26e95",
@@ -15654,7 +15654,7 @@
 		"altTitles": [],
 		"artist": "なきそ",
 		"data": {
-			"duration": null,
+			"duration": 119.478,
 			"genre": "niconico"
 		},
 		"id": "S19e3332af18aaad19ad",
@@ -15668,7 +15668,7 @@
 		"altTitles": [],
 		"artist": "アオワイファイ feat.犀羅",
 		"data": {
-			"duration": null,
+			"duration": 136.8,
 			"genre": "チュウマイ"
 		},
 		"id": "S19e3332af198ac2bf59",
@@ -15682,7 +15682,7 @@
 		"altTitles": [],
 		"artist": "Cosmograph",
 		"data": {
-			"duration": null,
+			"duration": 153.333,
 			"genre": "チュウマイ"
 		},
 		"id": "S19e3332af1a4324e042",
@@ -15694,7 +15694,7 @@
 		"altTitles": [],
 		"artist": "KiRaRe「Re:ステージ！プリズムステップ」",
 		"data": {
-			"duration": null,
+			"duration": 180.333,
 			"genre": "POPS＆ANIME"
 		},
 		"id": "S19e3332af1b6d64c4c2",
@@ -15706,7 +15706,7 @@
 		"altTitles": [],
 		"artist": "ステラマリス「Re:ステージ！プリズムステップ」",
 		"data": {
-			"duration": null,
+			"duration": 151.8,
 			"genre": "POPS＆ANIME"
 		},
 		"id": "S19e3332af1cecad0836",
@@ -15718,7 +15718,7 @@
 		"altTitles": [],
 		"artist": "トロワアンジュ「Re:ステージ！プリズムステップ」",
 		"data": {
-			"duration": null,
+			"duration": 126.316,
 			"genre": "POPS＆ANIME"
 		},
 		"id": "S19e3332af1d7403fa60",
@@ -15730,7 +15730,7 @@
 		"altTitles": [],
 		"artist": "曲：下野 隼／歌：結城 莉玖(CV：朝日奈 丸佳)、坂東 美久龍(CV：山田 奈都美)",
 		"data": {
-			"duration": null,
+			"duration": 142.418,
 			"genre": "オンゲキ"
 		},
 		"id": "S19e3332af1e2d70b9b6",
@@ -15742,7 +15742,7 @@
 		"altTitles": [],
 		"artist": "曲：矢鴇つかさ（Arte Refact）／歌：三角 葵(CV：春野 杏)",
 		"data": {
-			"duration": null,
+			"duration": 158.63,
 			"genre": "ボーナストラック"
 		},
 		"id": "S19e3332af1fd9db4e1f",
@@ -15756,7 +15756,7 @@
 		"altTitles": [],
 		"artist": "曲：矢鴇つかさ（Arte Refact）／歌：早乙女 彩華(CV：中島 唯)",
 		"data": {
-			"duration": null,
+			"duration": 158.63,
 			"genre": "ボーナストラック"
 		},
 		"id": "S19e3332af20cf956ec6",
@@ -15770,7 +15770,7 @@
 		"altTitles": [],
 		"artist": "曲：矢鴇つかさ（Arte Refact）／歌：柏木 咲姫(CV：石見 舞菜香)",
 		"data": {
-			"duration": null,
+			"duration": 158.63,
 			"genre": "ボーナストラック"
 		},
 		"id": "S19e3332af217e0e317c",


### PR DESCRIPTION
This is an update to the seeds for Ongeki that does three things:

- Adds song lengths for the Refresh Act 1 songs missing them
- Adds inGameIDs for the Refresh Act 1 charts missing them
- Adds a bunch of additional sdvx.in links for charts

Apologies if I botched something here (as it's my first time trying to update seeds), but it does pass all tests and load in my local dev instance and I did cross reference this against both the sdvx.in data and data generated from [other sources], so it should check out. (...hopefully?)